### PR TITLE
Final launch backend: limiter/shims/migration tidy + docs & smoke tests

### DIFF
--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -24,6 +24,10 @@ npm run migrate:quests
 node server.js
 ```
 
+## Render
+
+Node web service with 1GB persistent disk at `/var/data`.
+
 ## Smoke tests
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "NODE_ENV=development node server.js",
     "render-start": "node server.js",
     "migrate:quests": "sqlite3 $SQLITE_FILE < scripts/migrate-quests.sql",
-    "test": "node -e \"console.log('ok')\""
+    "test": "node tests/deriveLevel.smoke.js"
   },
   "engines": {
     "node": ">=18 <23"

--- a/server.js
+++ b/server.js
@@ -36,7 +36,12 @@ app.use(cors({
 
 app.use(express.json());
 
-const globalLimiter = rateLimit({ windowMs: 60_000, max: 200 });
+const globalLimiter = rateLimit({
+  windowMs: 60_000,
+  max: 200,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 app.use(globalLimiter);
 
 const claimLimiter = rateLimit({


### PR DESCRIPTION
## Summary
- enforce global rate limit headers and dedicated abuse protection for quest claiming
- run progression smoke test through `npm test`
- consolidate launch instructions with render setup and curl smoke tests

## Testing
- `npm test`
- `node --check server.js`
- `node server.js` (start + manual terminate)

## Smoke tests
```bash
BACKEND=https://sevengoldencowries-backend.onrender.com
curl -s $BACKEND/healthz
curl -s $BACKEND/api/meta/progression | jq
curl -s -H "x-wallet: UQTestWallet123" $BACKEND/api/quests | jq
curl -s -H "x-wallet: UQTestWallet123" -H "Content-Type: application/json" -d '{"questId":"join_telegram"}' $BACKEND/api/quests/claim | jq
curl -s -H "x-wallet: UQTestWallet123" $BACKEND/api/users/me | jq
```

------
https://chatgpt.com/codex/tasks/task_e_68babd930a58832b8e8849eec885485e