### PR TITLE
feat(backend): add /api/session/bind-wallet; session/CORS hardening; defensive wallet handling for quests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@ NODE_ENV=development
 CLIENT_ORIGIN=http://localhost:3000
 CORS_ORIGINS=https://7goldencowries.com,https://www.7goldencowries.com,https://7goldencowries-frontend.vercel.app
 SESSION_SECRET=changeme
+SESSION_NAME=7gc.sid
 SESSIONS_DIR=/var/data
 SQLITE_FILE=/var/data/7gc.sqlite
 TELEGRAM_BOT_TOKEN=

--- a/routes/questRoutes.js
+++ b/routes/questRoutes.js
@@ -318,9 +318,15 @@ router.post("/api/quest/complete", completeHandler);  // legacy
 // Idempotent quest XP claim
 router.post("/api/quests/claim", async (req, res) => {
   try {
-    const wallet = String(req.body?.wallet || req.get("x-wallet") || "").trim();
+    const wallet =
+      req.session.wallet || (req.query.wallet ? String(req.query.wallet) : null);
     const questIdentifier = req.body?.questId;
-    if (!wallet || questIdentifier === undefined || questIdentifier === null || questIdentifier === "") {
+    if (!wallet) {
+      return res
+        .status(400)
+        .json({ ok: false, error: "Missing wallet address" });
+    }
+    if (questIdentifier === undefined || questIdentifier === null || questIdentifier === "") {
       return res.status(400).json({ ok: false, error: "bad-args" });
     }
 


### PR DESCRIPTION
## Summary
- harden CORS and session cookies for production
- register /api/session/bind-wallet route
- read wallet from session in quest claim handler

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baf2392f78832bae3d9aa738b6d3cd