### PR TITLE
feat: admin quest seeder and live quests file

### DIFF
--- a/data/quests.live.json
+++ b/data/quests.live.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "q_follow_x",
+    "title": "Follow @7goldencowries on X",
+    "description": "Stay updated on quests, drops and XP boosts.",
+    "category": "Insider",
+    "kind": "social",
+    "url": "https://x.com/7goldencowries",
+    "xp": 50,
+    "active": true,
+    "sort": 10
+  },
+  {
+    "id": "q_join_telegram",
+    "title": "Join our Telegram",
+    "description": "Hang out with the Isles and catch early alpha.",
+    "category": "Social",
+    "kind": "social",
+    "url": "https://t.me/GOLDENCOWRIE",
+    "xp": 40,
+    "active": true,
+    "sort": 20
+  },
+  {
+    "id": "q_join_discord",
+    "title": "Join our Discord",
+    "description": "Get roles, badges and partner quests.",
+    "category": "Partner",
+    "kind": "social",
+    "url": "https://discord.gg/wdKntDQf",
+    "xp": 40,
+    "active": true,
+    "sort": 30
+  },
+  {
+    "id": "q_daily_visit",
+    "title": "Daily Visit",
+    "description": "Check in on Isles once per day.",
+    "category": "Daily",
+    "kind": "link",
+    "url": "https://7goldencowries.com/quests",
+    "xp": 10,
+    "active": true,
+    "sort": 5
+  },
+  {
+    "id": "q_tonconnect_bind",
+    "title": "Connect your TON wallet",
+    "description": "Bind your wallet to start earning XP.",
+    "category": "Onchain",
+    "kind": "onchain",
+    "url": "",
+    "xp": 25,
+    "active": true,
+    "sort": 1
+  }
+]
+

--- a/db.js
+++ b/db.js
@@ -65,24 +65,23 @@ const initDB = async () => {
     );
 
     CREATE TABLE IF NOT EXISTS quests (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      id TEXT PRIMARY KEY,
       title TEXT NOT NULL,
-      type TEXT NOT NULL,         -- daily | social | onchain | etc
-      url TEXT NOT NULL,
-      xp INTEGER NOT NULL,
-      requiredTier TEXT DEFAULT 'Free',
-      requiresTwitter INTEGER NOT NULL DEFAULT 0,
-      -- flexible gating
-      code TEXT UNIQUE,           -- stable code for admin/seed
-      requirement TEXT,           -- e.g. none | x_follow | tg_channel_member | tg_group_member | tg_bot_linked | discord_member
-      target TEXT,                -- e.g. @handle, invite link, group username
-      active INTEGER DEFAULT 1
+      description TEXT DEFAULT '',
+      category TEXT DEFAULT 'All',
+      kind TEXT DEFAULT 'link',            -- 'link' | 'social' | 'onchain' | etc.
+      url TEXT DEFAULT '',
+      xp INTEGER DEFAULT 0,
+      active INTEGER DEFAULT 1,
+      sort INTEGER DEFAULT 0,
+      createdAt INTEGER DEFAULT (strftime('%s','now')),
+      updatedAt INTEGER DEFAULT (strftime('%s','now'))
     );
 
     CREATE TABLE IF NOT EXISTS completed_quests (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       wallet TEXT NOT NULL,
-      questId INTEGER NOT NULL,
+      questId TEXT NOT NULL,
       timestamp TEXT NOT NULL,
       UNIQUE(wallet, questId)
     );
@@ -143,7 +142,6 @@ const initDB = async () => {
   `);
 
   // --- Indices (speed up common lookups) ---
-  await ensureIndex("idx_quests_code",      "ON quests(code)");
   await ensureIndex("idx_quests_active",    "ON quests(active)");
   await ensureIndex("idx_completed_wallet", "ON completed_quests(wallet)");
   await ensureIndex("idx_completed_qid",    "ON completed_quests(questId)");
@@ -181,13 +179,6 @@ const initDB = async () => {
   await addColumnIfMissing("users", "discordGuildMember",    `discordGuildMember INTEGER DEFAULT 0`);
   await addColumnIfMissing("users", "created_at",            `created_at DATETIME DEFAULT CURRENT_TIMESTAMP`);
 
-  // quests
-  await addColumnIfMissing("quests", "requiredTier",         `requiredTier TEXT DEFAULT 'Free'`);
-  await addColumnIfMissing("quests", "requiresTwitter",      `requiresTwitter INTEGER NOT NULL DEFAULT 0`);
-  await addColumnIfMissing("quests", "code",                 `code TEXT UNIQUE`);
-  await addColumnIfMissing("quests", "requirement",          `requirement TEXT`);
-  await addColumnIfMissing("quests", "target",               `target TEXT`);
-  await addColumnIfMissing("quests", "active",               `active INTEGER DEFAULT 1`);
 
   // social_links/referrals extras
   await addColumnIfMissing("social_links", "updated_at",     `updated_at DATETIME DEFAULT CURRENT_TIMESTAMP`);

--- a/lib/quests.js
+++ b/lib/quests.js
@@ -11,31 +11,23 @@ export async function awardQuest(wallet, questIdentifier) {
     return { ok: false, error: 'bad-args' };
   }
 
-  let quest;
-  if (typeof questIdentifier === 'string' && questIdentifier !== '') {
-    quest = await db.get('SELECT id, code, xp FROM quests WHERE code = ?', questIdentifier);
-    if (!quest) {
-      const idNum = Number(questIdentifier);
-      if (Number.isFinite(idNum)) {
-        quest = await db.get('SELECT id, code, xp FROM quests WHERE id = ?', idNum);
-      }
-    }
-  } else {
-    const idNum = Number(questIdentifier);
-    if (Number.isFinite(idNum)) {
-      quest = await db.get('SELECT id, code, xp FROM quests WHERE id = ?', idNum);
+  let quest = await db.get('SELECT id, xp FROM quests WHERE id = ?', questIdentifier);
+  if (!quest && typeof questIdentifier === 'string' && questIdentifier !== '') {
+    try {
+      quest = await db.get('SELECT id, xp FROM quests WHERE code = ?', questIdentifier);
+    } catch {
+      /* ignore if code column missing */
     }
   }
   if (!quest) return { ok: false, error: 'quest-not-found' };
 
   const qid = quest.id;
-  const qcode = quest.code;
 
   const isDone = await db.get(
     'SELECT 1 FROM completed_quests WHERE wallet = ? AND questId = ?',
     wallet, qid
   );
-  if (isDone) return { ok: true, xpGain: 0, already: true, questId: qcode };
+  if (isDone) return { ok: true, xpGain: 0, already: true, questId: qid };
 
   const now = Date.now();
   await db.run(
@@ -50,5 +42,5 @@ export async function awardQuest(wallet, questIdentifier) {
 
   await maybeCreditReferral(wallet);
 
-  return { ok: true, xpGain, already: false, questId: qcode };
+  return { ok: true, xpGain, already: false, questId: qid };
 }

--- a/lib/seedQuests.js
+++ b/lib/seedQuests.js
@@ -1,0 +1,43 @@
+import fs from "fs";
+import path from "path";
+import db from "../db.js";
+
+export async function seedQuestsFromFile(filePath) {
+  const full = path.resolve(filePath);
+  const raw = fs.readFileSync(full, "utf8");
+  const items = JSON.parse(raw);
+
+  const stmt = await db.prepare(`
+    INSERT INTO quests (id, title, description, category, kind, url, xp, active, sort, updatedAt)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%s','now'))
+    ON CONFLICT(id) DO UPDATE SET
+      title=excluded.title,
+      description=excluded.description,
+      category=excluded.category,
+      kind=excluded.kind,
+      url=excluded.url,
+      xp=excluded.xp,
+      active=excluded.active,
+      sort=excluded.sort,
+      updatedAt=strftime('%s','now')
+  `);
+
+  for (const q of items) {
+    await stmt.run(
+      q.id,
+      q.title,
+      q.description ?? "",
+      q.category ?? "All",
+      q.kind ?? "link",
+      q.url ?? "",
+      Number(q.xp ?? 0),
+      q.active === false ? 0 : 1,
+      Number(q.sort ?? 0)
+    );
+  }
+  await stmt.finalize();
+  return { count: items.length };
+}
+
+export default seedQuestsFromFile;
+

--- a/routes/adminRoutes.js
+++ b/routes/adminRoutes.js
@@ -1,93 +1,42 @@
 import express from "express";
+import { seedQuestsFromFile } from "../lib/seedQuests.js";
+import path from "path";
 import db from "../db.js";
 
 const router = express.Router();
-const ADMIN_SECRET = process.env.ADMIN_SECRET || "dev_admin_secret_change_me";
+const mustAuth = (req, res, next) => {
+  const header = req.get("X-Admin-Secret");
+  if (!process.env.ADMIN_SECRET || header !== process.env.ADMIN_SECRET) {
+    return res.status(401).json({ error: "unauthorized" });
+  }
+  next();
+};
 
-/* Public ping (no auth) to verify mount */
-router.get("/ping", (_req, res) => res.json({ ok: true, route: "admin" }));
-
-/* Require x-admin for everything below */
-router.use((req, res, next) => {
-  const key = req.header("x-admin");
-  if (key && key === ADMIN_SECRET) return next();
-  return res.status(401).json({ error: "Unauthorized" });
-});
-
-async function ensureQuestColumns() {
-  const cols = await db.all(`PRAGMA table_info(quests)`);
-  const names = new Set(cols.map(c => c.name));
-  const alters = [];
-  if (!names.has("requirement")) alters.push(`ALTER TABLE quests ADD COLUMN requirement TEXT;`);
-  if (!names.has("target"))      alters.push(`ALTER TABLE quests ADD COLUMN target TEXT;`);
-  if (!names.has("active"))      alters.push(`ALTER TABLE quests ADD COLUMN active INTEGER DEFAULT 1;`);
-  for (const sql of alters) { try { await db.run(sql); } catch(_e) {} }
-}
-
-router.post("/seed-quests", async (_req, res) => {
+router.post("/quests/seed", mustAuth, async (req, res) => {
   try {
-    await ensureQuestColumns();
-
-    // ensure code column
-    const cols = await db.all(`PRAGMA table_info(quests)`);
-    if (!cols.some(c => c.name === "code")) {
-      try { await db.run(`ALTER TABLE quests ADD COLUMN code TEXT UNIQUE;`); } catch(_e) {}
-    }
-
-    const quests = [
-      { code: "tg_join_channel",  title: "Enroll in the Official 7GoldenCowries Telegram Channel", xp: 5, type: "social", requirement: "tg_channel_member", target: "@GOLDENCOWRIE" },
-      { code: "tg_start_bot",     title: "Initiate the 7GoldenCowries Telegram Bot",               xp: 5, type: "social", requirement: "tg_bot_linked",     target: "@GOLDENCOWRIEBOT" },
-      { code: "tg_join_group",    title: "Enter the 7GoldenCowries Community Group",               xp: 5, type: "social", requirement: "tg_group_member",    target: "@sevengoldencowries" },
-      { code: "x_follow_main",    title: "Follow 7GoldenCowries on X",                             xp: 5, type: "social", requirement: "x_follow",           target: "@7goldencowries" },
-      { code: "x_follow_founder", title: "Follow the Founder on X",                                xp: 5, type: "social", requirement: "x_follow",           target: "@0X_deepseek" },
-      { code: "x_follow_partner", title: "Follow Our Ecosystem Partner on X",                      xp: 5, type: "social", requirement: "x_follow",           target: "@Gigilabs_" },
-      { code: "discord_join",     title: "Enter the 7GoldenCowries Discord Realm",                 xp: 5, type: "social", requirement: "discord_member",     target: "https://discord.gg/Yj9TQYdgSP" },
-    ];
-
-    for (const q of quests) {
-      await db.run(
-        `INSERT INTO quests (code, title, xp, type, requirement, target, active)
-         VALUES (?, ?, ?, ?, ?, ?, 1)
-         ON CONFLICT(code) DO UPDATE SET
-           title=excluded.title,
-           xp=excluded.xp,
-           type=excluded.type,
-           requirement=excluded.requirement,
-           target=excluded.target,
-           active=excluded.active`,
-        q.code, q.title, q.xp, q.type, q.requirement, q.target
-      );
-    }
-
-    res.json({ ok: true, upserted: quests.length });
+    const file = req.body?.file || "data/quests.live.json";
+    const full = path.resolve(file);
+    const result = await seedQuestsFromFile(full);
+    return res.json({ ok: true, ...result, file: full });
   } catch (e) {
-    console.error("seed-quests error:", e);
-    res.status(500).json({ error: "seed failed" });
+    console.error("seed quests error", e);
+    return res.status(500).json({ error: "internal" });
   }
 });
 
-router.post("/disable-others", async (_req, res) => {
+router.post("/quests/toggle", mustAuth, async (req, res) => {
   try {
-    await ensureQuestColumns();
-    const keep = [
-      "tg_join_channel","tg_start_bot","tg_join_group",
-      "x_follow_main","x_follow_founder","x_follow_partner","discord_join"
-    ];
-    await db.run(
-      `UPDATE quests SET active=0 WHERE code IS NULL OR code NOT IN (${keep.map(()=>"?").join(",")})`,
-      ...keep
-    );
-    const rows = await db.all(`SELECT id, code, title, active FROM quests ORDER BY id`);
-    res.json({ ok: true, total: rows.length, inactive: rows.filter(r=>r.active===0).length });
+    const { id, active } = req.body || {};
+    if (!id || typeof active === "undefined") {
+      return res.status(400).json({ error: "id and active required" });
+    }
+    await db.run(`UPDATE quests SET active=? WHERE id=?`, [active ? 1 : 0, id]);
+    return res.json({ ok: true, id, active: !!active });
   } catch (e) {
-    console.error("disable-others error:", e);
-    res.status(500).json({ error: "disable failed" });
+    console.error("toggle quest error", e);
+    return res.status(500).json({ error: "internal" });
   }
-});
-
-router.get("/dump-quests", async (_req, res) => {
-  const rows = await db.all(`SELECT id, code, title, requirement, target, xp, active FROM quests ORDER BY id`);
-  res.json(rows);
 });
 
 export default router;
+

--- a/server.js
+++ b/server.js
@@ -16,6 +16,7 @@ import referralRoutes, { admin as referralAdminRoutes } from "./routes/referralR
 import sessionRoutes from "./routes/sessionRoutes.js";
 import usersRoutes from "./routes/usersRoutes.js";
 import socialRoutes from "./routes/socialRoutes.js";
+import adminRoutes from "./routes/adminRoutes.js";
 
 dotenv.config();
 
@@ -100,6 +101,7 @@ app.use("/api/referrals", referralRoutes);
 app.use("/api/admin/referrals", referralAdminRoutes);
 app.use("/api/session", sessionRoutes);
 app.use("/auth", socialRoutes);
+app.use("/api/admin", adminRoutes);
 
 // temporary; keep until clients migrate
 app.get("/quests", (_req, res) => res.redirect(307, "/api/quests"));


### PR DESCRIPTION
## Summary
- add quests table with metadata fields and timestamp tracking
- seed quests from JSON and expose admin seeding/toggle routes
- pull active quests from DB for /api/quests

## Testing
- `npm test`
- `node -e "import('./lib/seedQuests.js').then(async m=>{const r=await m.seedQuestsFromFile('./data/quests.live.json'); console.log(r); process.exit(0);})"`


------
https://chatgpt.com/codex/tasks/task_e_68bb0f4f38d0832bb682b7dcfa219bc1