### PR TITLE
fix: auto-migrate quests table and harden quest listing

### DIFF
--- a/lib/ensureQuestsSchema.js
+++ b/lib/ensureQuestsSchema.js
@@ -1,0 +1,41 @@
+import db from "../db.js";
+
+/** Adds a column if it's missing. */
+async function addColumnIfMissing(table, name, defSql) {
+  const cols = await db.all(`PRAGMA table_info(${table})`);
+  const has = cols.some((c) => c.name === name);
+  if (!has) {
+    await db.run(`ALTER TABLE ${table} ADD COLUMN ${name} ${defSql}`);
+  }
+}
+
+export async function ensureQuestsSchema() {
+  // Make sure table exists
+  await db.run(`
+    CREATE TABLE IF NOT EXISTS quests (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      description TEXT DEFAULT '',
+      category TEXT DEFAULT 'All',
+      kind TEXT DEFAULT 'link',
+      url TEXT DEFAULT '',
+      xp INTEGER DEFAULT 0,
+      active INTEGER DEFAULT 1,
+      sort INTEGER DEFAULT 0,
+      createdAt INTEGER DEFAULT (strftime('%s','now')),
+      updatedAt INTEGER DEFAULT (strftime('%s','now'))
+    );
+  `);
+
+  // Backfill columns if this DB had an older schema
+  await addColumnIfMissing("quests", "description", `TEXT DEFAULT ''`);
+  await addColumnIfMissing("quests", "category", `TEXT DEFAULT 'All'`);
+  await addColumnIfMissing("quests", "kind", `TEXT DEFAULT 'link'`);
+  await addColumnIfMissing("quests", "url", `TEXT DEFAULT ''`);
+  await addColumnIfMissing("quests", "xp", `INTEGER DEFAULT 0`);
+  await addColumnIfMissing("quests", "active", `INTEGER DEFAULT 1`);
+  await addColumnIfMissing("quests", "sort", `INTEGER DEFAULT 0`);
+  await addColumnIfMissing("quests", "createdAt", `INTEGER DEFAULT (strftime('%s','now'))`);
+  await addColumnIfMissing("quests", "updatedAt", `INTEGER DEFAULT (strftime('%s','now'))`);
+}
+

--- a/routes/questRoutes.js
+++ b/routes/questRoutes.js
@@ -86,9 +86,22 @@ async function discordIsMember(accessToken, guildId) {
 
 async function listQuestsHandler(_req, res) {
   try {
-    const rows = await db.all(
-      `SELECT * FROM quests WHERE active=1 ORDER BY sort ASC, createdAt DESC`
-    );
+    const rows = await db.all(`
+      SELECT
+        id,
+        title,
+        COALESCE(description,'') AS description,
+        COALESCE(category,'All') AS category,
+        COALESCE(kind,'link') AS kind,
+        COALESCE(url,'') AS url,
+        COALESCE(xp,0) AS xp,
+        COALESCE(active,1) AS active,
+        COALESCE(sort,0) AS sort,
+        COALESCE(updatedAt, createdAt, 0) AS updatedAt
+      FROM quests
+      WHERE COALESCE(active,1) = 1
+      ORDER BY COALESCE(sort,0) ASC, COALESCE(updatedAt, createdAt, 0) DESC
+    `);
     const quests = rows.map(normalizeQuestRow);
 
     if (String(_req.query.flat || "") === "1") return res.json(quests);

--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ import session from "express-session";
 import MemoryStore from "memorystore";
 import morgan from "morgan";
 import db from "./db.js";
+import { ensureQuestsSchema } from "./lib/ensureQuestsSchema.js";
 import metaRoutes from "./routes/metaRoutes.js";
 import questRoutes from "./routes/questRoutes.js";
 import userRoutes from "./routes/userRoutes.js";
@@ -90,6 +91,8 @@ app.get("/healthz", async (_req, res) => {
     res.status(500).json({ ok: false, db: "error" });
   }
 });
+
+await ensureQuestsSchema();
 
 app.use(metaRoutes);
 app.use(questRoutes);


### PR DESCRIPTION
## Summary
- ensure quests table has required columns with defaults on startup
- handle missing quest fields in /api/quests and order safely

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb1ba8700c832b8721a9b066dd288e