### PR TITLE
fix(db): SQLite-safe schema migrator (no expression defaults on ADD COLUMN) + timestamp backfill

### DIFF
--- a/lib/ensureQuestsSchema.js
+++ b/lib/ensureQuestsSchema.js
@@ -1,33 +1,35 @@
 import db from "../db.js";
 
-/** Adds a column if it's missing. */
-async function addColumnIfMissing(table, name, defSql) {
+async function hasColumn(table, name) {
   const cols = await db.all(`PRAGMA table_info(${table})`);
-  const has = cols.some((c) => c.name === name);
-  if (!has) {
-    await db.run(`ALTER TABLE ${table} ADD COLUMN ${name} ${defSql}`);
+  return cols.some(c => c.name === name);
+}
+
+async function addColumnIfMissing(table, name, typeAndDefaultSql) {
+  if (!(await hasColumn(table, name))) {
+    await db.run(`ALTER TABLE ${table} ADD COLUMN ${name} ${typeAndDefaultSql}`);
   }
 }
 
 export async function ensureQuestsSchema() {
-  // Make sure table exists
+  // 1) Ensure table exists with only constant defaults (SQLite restriction)
   await db.run(`
     CREATE TABLE IF NOT EXISTS quests (
-      id TEXT PRIMARY KEY,
-      title TEXT NOT NULL,
+      id         TEXT PRIMARY KEY,
+      title      TEXT NOT NULL,
       description TEXT DEFAULT '',
-      category TEXT DEFAULT 'All',
-      kind TEXT DEFAULT 'link',
-      url TEXT DEFAULT '',
-      xp INTEGER DEFAULT 0,
-      active INTEGER DEFAULT 1,
-      sort INTEGER DEFAULT 0,
-      createdAt INTEGER DEFAULT (strftime('%s','now')),
-      updatedAt INTEGER DEFAULT (strftime('%s','now'))
+      category    TEXT DEFAULT 'All',
+      kind        TEXT DEFAULT 'link',
+      url         TEXT DEFAULT '',
+      xp          INTEGER DEFAULT 0,
+      active      INTEGER DEFAULT 1,
+      sort        INTEGER DEFAULT 0,
+      createdAt   INTEGER,
+      updatedAt   INTEGER
     );
   `);
 
-  // Backfill columns if this DB had an older schema
+  // 2) Columns that might be missing on older DBs (ONLY constant defaults here)
   await addColumnIfMissing("quests", "description", `TEXT DEFAULT ''`);
   await addColumnIfMissing("quests", "category", `TEXT DEFAULT 'All'`);
   await addColumnIfMissing("quests", "kind", `TEXT DEFAULT 'link'`);
@@ -35,7 +37,11 @@ export async function ensureQuestsSchema() {
   await addColumnIfMissing("quests", "xp", `INTEGER DEFAULT 0`);
   await addColumnIfMissing("quests", "active", `INTEGER DEFAULT 1`);
   await addColumnIfMissing("quests", "sort", `INTEGER DEFAULT 0`);
-  await addColumnIfMissing("quests", "createdAt", `INTEGER DEFAULT (strftime('%s','now'))`);
-  await addColumnIfMissing("quests", "updatedAt", `INTEGER DEFAULT (strftime('%s','now'))`);
+  await addColumnIfMissing("quests", "createdAt", `INTEGER`);
+  await addColumnIfMissing("quests", "updatedAt", `INTEGER`);
+
+  // 3) Backfill timestamps in a separate step (expressions are OK in UPDATE)
+  await db.run(`UPDATE quests SET createdAt = COALESCE(createdAt, strftime('%s','now'))`);
+  await db.run(`UPDATE quests SET updatedAt = COALESCE(updatedAt, createdAt)`);
 }
 


### PR DESCRIPTION
## Summary
- use a safer `ensureQuestsSchema` that avoids expression defaults on `ALTER TABLE`
- backfill `createdAt` and `updatedAt` with update queries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb243b6fb4832ba66d352a88caff7f