### PR TITLE
Add updatedAt column migration for users

### DIFF
--- a/db.js
+++ b/db.js
@@ -182,6 +182,7 @@ const initDB = async () => {
   await addColumnIfMissing("users", "discordRefreshToken",   `discordRefreshToken TEXT`);
   await addColumnIfMissing("users", "discordTokenExpiresAt", `discordTokenExpiresAt INTEGER`);
   await addColumnIfMissing("users", "discordGuildMember",    `discordGuildMember INTEGER DEFAULT 0`);
+  await addColumnIfMissing("users", "updatedAt",             `updatedAt DATETIME DEFAULT CURRENT_TIMESTAMP`);
   await addColumnIfMissing("users", "created_at",            `created_at DATETIME DEFAULT CURRENT_TIMESTAMP`);
   await addColumnIfMissing("users", "telegram_username",     `telegram_username TEXT`);
   await addColumnIfMissing("users", "twitter_username",      `twitter_username TEXT`);


### PR DESCRIPTION
## Summary
- ensure `users.updatedAt` column exists during backward-compatible migrations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb846a12d0832bb52377a5d7a2111e