### PR TITLE
Remove default updatedAt and backfill

### DIFF
--- a/db.js
+++ b/db.js
@@ -66,7 +66,7 @@ const initDB = async () => {
       discordTokenExpiresAt INTEGER,
       discordGuildMember INTEGER DEFAULT 0,
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-      updatedAt DATETIME DEFAULT CURRENT_TIMESTAMP
+      updatedAt DATETIME
     );
 
     CREATE TABLE IF NOT EXISTS quests (
@@ -182,7 +182,10 @@ const initDB = async () => {
   await addColumnIfMissing("users", "discordRefreshToken",   `discordRefreshToken TEXT`);
   await addColumnIfMissing("users", "discordTokenExpiresAt", `discordTokenExpiresAt INTEGER`);
   await addColumnIfMissing("users", "discordGuildMember",    `discordGuildMember INTEGER DEFAULT 0`);
-  await addColumnIfMissing("users", "updatedAt",             `updatedAt DATETIME DEFAULT CURRENT_TIMESTAMP`);
+  await addColumnIfMissing("users", "updatedAt",             `updatedAt DATETIME`);
+  await db.exec(
+    "UPDATE users SET updatedAt = strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE updatedAt IS NULL"
+  );
   await addColumnIfMissing("users", "created_at",            `created_at DATETIME DEFAULT CURRENT_TIMESTAMP`);
   await addColumnIfMissing("users", "telegram_username",     `telegram_username TEXT`);
   await addColumnIfMissing("users", "twitter_username",      `twitter_username TEXT`);

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -33,9 +33,10 @@ async function ensureUser(wallet, extra = {}) {
       `INSERT INTO users (
          wallet, xp, tier, levelName, levelSymbol, levelProgress, nextXP,
          twitterHandle, telegramId, telegramHandle,
-         discordId, discordHandle, discordGuildMember
+         discordId, discordHandle, discordGuildMember,
+         updatedAt
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))`,
       wallet,
       extra.xp ?? 0,
       extra.tier ?? "Free",

--- a/routes/discordAuth.js
+++ b/routes/discordAuth.js
@@ -66,14 +66,15 @@ router.get("/discord/callback", async (req, res) => {
     const discordHandle = me.username ? `${me.username}${discriminator}` : "";
 
     await db.run(
-      `INSERT INTO users (wallet, discordId, discordHandle, discordAccessToken, discordRefreshToken, discordTokenExpiresAt)
-       VALUES (?, ?, ?, ?, ?, ?)
+      `INSERT INTO users (wallet, discordId, discordHandle, discordAccessToken, discordRefreshToken, discordTokenExpiresAt, updatedAt)
+       VALUES (?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))
        ON CONFLICT(wallet) DO UPDATE SET
          discordId=excluded.discordId,
          discordHandle=excluded.discordHandle,
          discordAccessToken=excluded.discordAccessToken,
          discordRefreshToken=excluded.discordRefreshToken,
-         discordTokenExpiresAt=excluded.discordTokenExpiresAt`,
+         discordTokenExpiresAt=excluded.discordTokenExpiresAt,
+         updatedAt=excluded.updatedAt`,
       wallet, discordId, discordHandle, accessToken, refreshToken, tokenExpiresAt
     );
 

--- a/routes/profileRoutes.js
+++ b/routes/profileRoutes.js
@@ -30,8 +30,8 @@ async function ensureUserRow(wallet) {
   const row = await db.get("SELECT wallet FROM users WHERE wallet = ?", wallet);
   if (!row) {
     await db.run(
-      `INSERT INTO users (wallet, xp, tier, levelName, levelSymbol, levelProgress, nextXP)
-       VALUES (?, 0, 'Free', 'Shellborn', '🐚', 0, 10000)`,
+      `INSERT INTO users (wallet, xp, tier, levelName, levelSymbol, levelProgress, nextXP, updatedAt)
+       VALUES (?, 0, 'Free', 'Shellborn', '🐚', 0, 10000, strftime('%Y-%m-%dT%H:%M:%fZ','now'))`,
       wallet
     );
   }

--- a/routes/sessionRoutes.js
+++ b/routes/sessionRoutes.js
@@ -9,8 +9,8 @@ async function ensureUser(wallet) {
   const row = await db.get("SELECT wallet FROM users WHERE wallet = ?", wallet);
   if (!row) {
     await db.run(
-      `INSERT INTO users (wallet, xp, tier, levelName, levelSymbol, levelProgress, nextXP)
-       VALUES (?, 0, 'Free', 'Shellborn', '🐚', 0, 10000)`,
+      `INSERT INTO users (wallet, xp, tier, levelName, levelSymbol, levelProgress, nextXP, updatedAt)
+       VALUES (?, 0, 'Free', 'Shellborn', '🐚', 0, 10000, strftime('%Y-%m-%dT%H:%M:%fZ','now'))`,
       wallet
     );
   }

--- a/routes/telegramRoutes.js
+++ b/routes/telegramRoutes.js
@@ -83,8 +83,8 @@ async function ensureUser(wallet) {
   const row = await db.get("SELECT wallet FROM users WHERE wallet = ?", wallet);
   if (!row) {
     await db.run(
-      `INSERT INTO users (wallet, xp, tier, levelName, levelSymbol, levelProgress, nextXP)
-       VALUES (?, 0, 'Free', 'Shellborn', '🐚', 0, 10000)`,
+      `INSERT INTO users (wallet, xp, tier, levelName, levelSymbol, levelProgress, nextXP, updatedAt)
+       VALUES (?, 0, 'Free', 'Shellborn', '🐚', 0, 10000, strftime('%Y-%m-%dT%H:%M:%fZ','now'))`,
       wallet
     );
   }

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -18,7 +18,7 @@ async function fetchUser(wallet, res) {
 
     if (!user) {
       await db.run(
-        `INSERT INTO users (wallet, xp, tier, levelName, levelProgress)\n         VALUES (?, ?, ?, ?, ?)`,
+        `INSERT INTO users (wallet, xp, tier, levelName, levelProgress, updatedAt)\n         VALUES (?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))`,
         wallet, 0, "Free", "Shellborn", 0
       );
       user = await db.get("SELECT * FROM users WHERE wallet = ?", wallet);

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -11,7 +11,7 @@ beforeAll(async () => {
   ({ default: db } = await import('../db.js'));
   try { await db.exec("ALTER TABLE quests ADD COLUMN code TEXT;"); } catch {}
   await db.run("INSERT INTO quests (id, code, title, xp, active) VALUES ('q1','Q1','Test Quest',10,1)");
-  await db.run("INSERT INTO users (wallet) VALUES ('w1')");
+  await db.run("INSERT INTO users (wallet, updatedAt) VALUES ('w1', CURRENT_TIMESTAMP)");
 });
 
 afterAll(async () => {

--- a/tests/awardQuest.test.js
+++ b/tests/awardQuest.test.js
@@ -6,8 +6,8 @@ beforeAll(async () => {
   ({ awardQuest } = await import('../lib/quests.js'));
   try { await db.exec("ALTER TABLE quests ADD COLUMN code TEXT;"); } catch {}
   await db.run("INSERT INTO quests (id, code, title, xp, active) VALUES ('q1','Q1','Test Quest',10,1)");
-  await db.run("INSERT INTO users (wallet) VALUES ('wallet1')");
-  await db.run("INSERT INTO users (wallet) VALUES ('wallet2')");
+  await db.run("INSERT INTO users (wallet, updatedAt) VALUES ('wallet1', CURRENT_TIMESTAMP)");
+  await db.run("INSERT INTO users (wallet, updatedAt) VALUES ('wallet2', CURRENT_TIMESTAMP)");
 });
 
 afterAll(async () => {


### PR DESCRIPTION
## Summary
- Drop default CURRENT_TIMESTAMP on users.updatedAt and backfill NULL entries
- Ensure all user creation/upsert paths explicitly set updatedAt
- Adjust tests for explicit updatedAt field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb865de208832bab90de7c7ae03468