### PR TITLE
feat: apply tier-based XP multipliers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ node server.js
 - `POST /api/quests/claim?wallet=ADDR` `{ "questId": "..." }` – idempotent claim, responds with `alreadyClaimed` when repeated
 - `GET /api/leaderboard` – top users by XP
 
+### Tier multipliers
+
+User tiers (Free, Tier1, Tier2, Tier3) are stored in the `users.tier` column.  XP boosts are defined in the
+`tier_multipliers` table (`tier`, `multiplier`, `label`) and can be edited without code changes.  Claiming a quest
+applies the multiplier and reports the effective XP.
+
 Legacy endpoints `/quests` and `/complete` redirect to the new routes and will be removed after **1 Jan 2025**. Update clients before this date.
 
 ## Disk

--- a/db.js
+++ b/db.js
@@ -144,6 +144,12 @@ const initDB = async () => {
       tx_hash TEXT,                        -- optional onchain tx id
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
+
+    CREATE TABLE IF NOT EXISTS tier_multipliers (
+      tier TEXT PRIMARY KEY,
+      multiplier REAL DEFAULT 1.0,
+      label TEXT
+    );
   `);
 
   // --- Indices (speed up common lookups) ---

--- a/lib/quests.js
+++ b/lib/quests.js
@@ -1,6 +1,7 @@
 // lib/quests.js
 import db from '../db.js';
 import { maybeCreditReferral } from '../utils/referrals.js';
+import { getTierMultiplier } from '../utils/tier.js';
 
 /**
  * Idempotently award a quest's XP to a wallet and record completion.
@@ -34,13 +35,15 @@ export async function awardQuest(wallet, questIdentifier) {
     'INSERT INTO completed_quests (wallet, questId, timestamp) VALUES (?, ?, ?)',
     wallet, qid, now
   );
-  const xpGain = quest.xp ?? 0;
-    await db.run(
-      "UPDATE users SET xp = COALESCE(xp, 0) + ?, updatedAt = strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE wallet = ?",
-      xpGain, wallet
-    );
+  const baseXp = quest.xp ?? 0;
+  const multiplier = await getTierMultiplier(db, wallet);
+  const xpGain = Math.round(baseXp * multiplier);
+  await db.run(
+    "UPDATE users SET xp = COALESCE(xp, 0) + ?, updatedAt = strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE wallet = ?",
+    xpGain, wallet
+  );
 
   await maybeCreditReferral(wallet);
 
-  return { ok: true, xpGain, already: false, questId: qid };
+  return { ok: true, baseXp, multiplier, xpGain, already: false, questId: qid };
 }

--- a/routes/adminRoutes.js
+++ b/routes/adminRoutes.js
@@ -38,5 +38,38 @@ router.post("/quests/toggle", mustAuth, async (req, res) => {
   }
 });
 
+// Update a user's tier
+router.post("/users/tier", mustAuth, async (req, res) => {
+  try {
+    const { wallet, tier } = req.body || {};
+    const allowed = new Set(["free", "tier1", "tier2", "tier3"]);
+    if (!wallet || !tier || !allowed.has(String(tier).toLowerCase())) {
+      return res.status(400).json({ error: "wallet and valid tier required" });
+    }
+    await db.run(
+      `UPDATE users SET tier = ?, updatedAt = strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE wallet = ?`,
+      tier,
+      wallet
+    );
+    return res.json({ ok: true, wallet, tier });
+  } catch (e) {
+    console.error("update user tier error", e);
+    return res.status(500).json({ error: "internal" });
+  }
+});
+
+// List available tiers and multipliers
+router.get("/tiers", mustAuth, async (_req, res) => {
+  try {
+    const tiers = await db.all(
+      `SELECT tier, multiplier, label FROM tier_multipliers ORDER BY tier`
+    );
+    return res.json({ tiers });
+  } catch (e) {
+    console.error("list tiers error", e);
+    return res.status(500).json({ error: "internal" });
+  }
+});
+
 export default router;
 

--- a/routes/usersRoutes.js
+++ b/routes/usersRoutes.js
@@ -24,9 +24,14 @@ router.get("/me", async (req, res) => {
     );
 
     const row = await db.get(
-      `SELECT wallet, xp, telegram_username, twitter_username, twitter_id,
-              discord_username, discord_id
-         FROM users WHERE wallet = ?`,
+      `SELECT u.wallet, u.xp, u.tier,
+              COALESCE(m.label, u.tier, 'Free') AS tierLabel,
+              COALESCE(m.multiplier, 1.0) AS multiplier,
+              u.telegram_username, u.twitter_username, u.twitter_id,
+              u.discord_username, u.discord_id
+         FROM users u
+         LEFT JOIN tier_multipliers m ON m.tier = u.tier
+        WHERE u.wallet = ?`,
       wallet
     );
 
@@ -54,6 +59,9 @@ router.get("/me", async (req, res) => {
       xp,
       level: lvl.levelName,
       levelProgress: lvl.progress,
+      tier: row?.tier || 'Free',
+      tierLabel: row?.tierLabel || (row?.tier || 'Free'),
+      multiplier: row?.multiplier ?? 1.0,
       socials,
     });
   } catch (e) {

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -10,8 +10,14 @@ beforeAll(async () => {
   ({ default: app } = await import('../server.js'));
   ({ default: db } = await import('../db.js'));
   try { await db.exec("ALTER TABLE quests ADD COLUMN code TEXT;"); } catch {}
-  await db.run("INSERT INTO quests (id, code, title, xp, active) VALUES ('q1','Q1','Test Quest',10,1)");
-  await db.run("INSERT INTO users (wallet, updatedAt) VALUES ('w1', CURRENT_TIMESTAMP)");
+  await db.exec(`CREATE TABLE IF NOT EXISTS tier_multipliers (
+      tier TEXT PRIMARY KEY,
+      multiplier REAL,
+      label TEXT
+    );`);
+  await db.run("INSERT INTO tier_multipliers (tier,multiplier,label) VALUES ('free',1.0,'Free'),('tier1',1.1,'Tier 1'),('tier3',1.5,'Tier 3')");
+  await db.run("INSERT INTO quests (id, code, title, xp, active) VALUES ('q1','Q1','Test Quest',100,1)");
+  await db.run("INSERT INTO users (wallet, tier, updatedAt) VALUES ('w1','tier1', CURRENT_TIMESTAMP)");
 });
 
 afterAll(async () => {
@@ -22,17 +28,28 @@ describe('API routes', () => {
   test('claims quest and reports alreadyClaimed', async () => {
     const first = await request(app).post('/api/quests/claim?wallet=w1').send({ questId: 'q1' });
     expect(first.body.ok).toBe(true);
+    expect(first.body.effectiveXp).toBe(110);
+    expect(first.body.baseXp).toBe(100);
+    expect(first.body.multiplier).toBeCloseTo(1.1);
+    expect(first.body.newTotalXp).toBe(110);
     const second = await request(app).post('/api/quests/claim?wallet=w1').send({ questId: 'q1' });
     expect(second.body.alreadyClaimed).toBe(true);
   });
 
   test('returns user stats', async () => {
     const res = await request(app).get('/api/users/w1');
-    expect(res.body.xp).toBe(10);
+    expect(res.body.xp).toBe(110);
   });
 
   test('leaderboard shows users', async () => {
     const res = await request(app).get('/api/leaderboard');
     expect(res.body.top[0].wallet).toBe('w1');
+  });
+
+  test('/api/users/me exposes tier and multiplier', async () => {
+    const res = await request(app).get('/api/users/me?wallet=w1');
+    expect(res.body.tier).toBe('tier1');
+    expect(res.body.tierLabel).toBe('Tier 1');
+    expect(res.body.multiplier).toBeCloseTo(1.1);
   });
 });

--- a/tests/awardQuest.test.js
+++ b/tests/awardQuest.test.js
@@ -5,9 +5,16 @@ beforeAll(async () => {
   ({ default: db } = await import('../db.js'));
   ({ awardQuest } = await import('../lib/quests.js'));
   try { await db.exec("ALTER TABLE quests ADD COLUMN code TEXT;"); } catch {}
-  await db.run("INSERT INTO quests (id, code, title, xp, active) VALUES ('q1','Q1','Test Quest',10,1)");
-  await db.run("INSERT INTO users (wallet, updatedAt) VALUES ('wallet1', CURRENT_TIMESTAMP)");
-  await db.run("INSERT INTO users (wallet, updatedAt) VALUES ('wallet2', CURRENT_TIMESTAMP)");
+  await db.exec(`CREATE TABLE IF NOT EXISTS tier_multipliers (
+        tier TEXT PRIMARY KEY,
+        multiplier REAL,
+        label TEXT
+      );`);
+  await db.run("INSERT INTO tier_multipliers (tier,multiplier,label) VALUES ('free',1.0,'Free'),('tier1',1.1,'Tier 1'),('tier3',1.5,'Tier 3')");
+  await db.run("INSERT INTO quests (id, code, title, xp, active) VALUES ('q1','Q1','Test Quest',100,1)");
+  await db.run("INSERT INTO users (wallet, tier, updatedAt) VALUES ('wallet1','free', CURRENT_TIMESTAMP)");
+  await db.run("INSERT INTO users (wallet, tier, updatedAt) VALUES ('wallet2','tier1', CURRENT_TIMESTAMP)");
+  await db.run("INSERT INTO users (wallet, tier, updatedAt) VALUES ('wallet3','tier3', CURRENT_TIMESTAMP)");
 });
 
 afterAll(async () => {
@@ -15,12 +22,16 @@ afterAll(async () => {
 });
 
 describe('awardQuest', () => {
-  test('awards xp for valid quest', async () => {
-    const res = await awardQuest('wallet1', 'q1');
-    expect(res.ok).toBe(true);
-    expect(res.already).toBe(false);
-    const row = await db.get("SELECT xp FROM users WHERE wallet='wallet1'");
-    expect(row.xp).toBe(10);
+  test('applies tier multipliers', async () => {
+    await awardQuest('wallet1', 'q1'); // free
+    await awardQuest('wallet2', 'q1'); // tier1
+    await awardQuest('wallet3', 'q1'); // tier3
+    const r1 = await db.get("SELECT xp FROM users WHERE wallet='wallet1'");
+    const r2 = await db.get("SELECT xp FROM users WHERE wallet='wallet2'");
+    const r3 = await db.get("SELECT xp FROM users WHERE wallet='wallet3'");
+    expect(r1.xp).toBe(100);
+    expect(r2.xp).toBe(110);
+    expect(r3.xp).toBe(150);
   });
 
   test('rejects invalid quest', async () => {
@@ -30,10 +41,10 @@ describe('awardQuest', () => {
   });
 
   test('prevents duplicate claims', async () => {
-    await awardQuest('wallet2', 'q1');
-    const again = await awardQuest('wallet2', 'q1');
+    await awardQuest('wallet1', 'q1');
+    const again = await awardQuest('wallet1', 'q1');
     expect(again.already).toBe(true);
-    const row = await db.get("SELECT xp FROM users WHERE wallet='wallet2'");
-    expect(row.xp).toBe(10);
+    const row = await db.get("SELECT xp FROM users WHERE wallet='wallet1'");
+    expect(row.xp).toBe(100); // unchanged
   });
 });

--- a/utils/tier.js
+++ b/utils/tier.js
@@ -1,0 +1,18 @@
+/**
+ * Return XP multiplier for a wallet's tier. Defaults to 1.0 when tier missing.
+ * @param {object} dbConn - sqlite database connection
+ * @param {string} wallet - user wallet address
+ * @returns {Promise<number>}
+ */
+export async function getTierMultiplier(dbConn, wallet) {
+  if (!wallet) return 1.0;
+  const row = await dbConn.get(
+    `SELECT COALESCE(m.multiplier, 1.0) AS mult
+       FROM users u LEFT JOIN tier_multipliers m ON m.tier = u.tier
+      WHERE u.wallet = ?
+      LIMIT 1`,
+    wallet
+  );
+  return row?.mult ?? 1.0;
+}
+


### PR DESCRIPTION
## Summary
- compute quest XP using tier multipliers and report effective XP
- expose user tier details and multiplier
- add admin tier management endpoints and docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb8b69cc68832b89878b9fe7ad7916