### PR TITLE
feat: add tweet proof verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,8 @@ TELEGRAM_BOT_USERNAME=
 
 # TON Connect manifest URL for wallet integration
 TONCONNECT_MANIFEST_URL=
+
+# X / Twitter quest verification
+X_TARGET_HANDLE=7goldencowries
+X_TARGET_TWEET_URL=https://x.com/7goldencowries/status/123456789
+X_REQUIRED_HASHTAG=#7GC

--- a/db.js
+++ b/db.js
@@ -122,6 +122,19 @@ const initDB = async () => {
       completed_at TEXT DEFAULT (datetime('now'))
     );
 
+    -- User submitted proofs for off-chain verification
+    CREATE TABLE IF NOT EXISTS quest_proofs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      wallet TEXT NOT NULL,
+      quest_id TEXT NOT NULL,
+      url TEXT NOT NULL,
+      status TEXT DEFAULT 'pending',         -- pending | verified | rejected
+      details TEXT,
+      createdAt TEXT DEFAULT (datetime('now')),
+      verifiedAt TEXT,
+      UNIQUE(wallet, quest_id)
+    );
+
     -- Subscriptions (used by daily expiry cron in index.js)
     -- status: active | expired | canceled
     CREATE TABLE IF NOT EXISTS subscriptions (
@@ -158,6 +171,9 @@ const initDB = async () => {
   await ensureIndex("idx_completed_qid",    "ON completed_quests(questId)");
   await ensureIndex("idx_completed_wallet_qid_time", "ON completed_quests(wallet, questId, timestamp)");
   await ensureUniqueIndex("uq_completed_wallet_quest", "ON completed_quests(wallet, questId)");
+  await ensureIndex("idx_proofs_wallet",    "ON quest_proofs(wallet)");
+  await ensureIndex("idx_proofs_status",    "ON quest_proofs(status)");
+  await ensureUniqueIndex("uq_proofs_wallet_quest", "ON quest_proofs(wallet, quest_id)");
   await ensureIndex("idx_history_wallet",   "ON quest_history(wallet)");
   await ensureIndex("idx_referrals_ref",    "ON referrals(referrer)");
   await ensureIndex("idx_referrals_red",    "ON referrals(referred)");

--- a/lib/twitterProof.js
+++ b/lib/twitterProof.js
@@ -1,0 +1,66 @@
+import { getCache, setCache } from '../utils/cache.js';
+
+// Parse https://x.com/{user}/status/{id} or twitter.com
+export function parseTweetUrl(url) {
+  const m = /^https:\/\/(?:x|twitter)\.com\/([^/]+)\/status\/(\d+)/i.exec(url);
+  if (!m) return null;
+  return { username: m[1], tweetId: m[2] };
+}
+
+async function fetchOEmbed(url, tweetId, fetchFn) {
+  const cacheKey = `oembed:${tweetId}`;
+  const cached = getCache(cacheKey);
+  if (cached) return cached;
+  try {
+    const res = await fetchFn(`https://publish.twitter.com/oembed?omit_script=1&url=${encodeURIComponent(url)}`);
+    if (res && res.ok) {
+      const data = await res.json();
+      setCache(cacheKey, data, 5 * 60 * 1000);
+      return data;
+    }
+  } catch {}
+  try {
+    const res = await fetchFn(url, { headers: { 'User-Agent': 'Mozilla/5.0' } });
+    if (res && res.ok) {
+      const html = await res.text();
+      const ogTitleMatch = html.match(/<meta[^>]+property="og:title"[^>]+content="([^"]*)"/i);
+      const ogDescMatch = html.match(/<meta[^>]+property="og:description"[^>]+content="([^"]*)"/i);
+      const data = { html, author_name: ogTitleMatch?.[1], ogDescription: ogDescMatch?.[1] };
+      setCache(cacheKey, data, 5 * 60 * 1000);
+      return data;
+    }
+  } catch {}
+  return null;
+}
+
+export async function verifyTwitterProof({ user, quest, url }, fetchFn = fetch) {
+  const parsed = parseTweetUrl(url);
+  if (!parsed) return { ok: false, details: 'Invalid tweet URL' };
+  const handle = (user?.twitter_username || user?.twitterHandle || '').toLowerCase();
+  if (!handle) return { ok: false, details: 'Twitter not linked' };
+  if (handle !== parsed.username.toLowerCase()) {
+    return { ok: false, details: 'Tweet user mismatch' };
+  }
+  const data = await fetchOEmbed(url, parsed.tweetId, fetchFn);
+  if (!data) return { ok: false, details: 'Tweet fetch failed' };
+  const html = (data.html || '').toLowerCase();
+  const meta = [(data.author_name || ''), (data.author_url || ''), (data.ogDescription || '')]
+    .join(' ')
+    .toLowerCase();
+  const text = html + ' ' + meta;
+  const targetUrl = (process.env.X_TARGET_TWEET_URL || '').toLowerCase();
+  const hashtag = (process.env.X_REQUIRED_HASHTAG || '').toLowerCase();
+  const handleTarget = (process.env.X_TARGET_HANDLE || '').toLowerCase();
+  const followPhrase = handleTarget ? `i'm following @${handleTarget}` : "";
+  const followHash = '#7gcfollow';
+  let verified = false;
+  if (targetUrl && html.includes(targetUrl.toLowerCase())) verified = true;
+  if (!verified && hashtag && text.includes(hashtag)) verified = true;
+  if (!verified && followPhrase && text.includes(followPhrase) && text.includes(followHash)) {
+    verified = true;
+  }
+  if (!verified) {
+    return { ok: false, details: 'Tweet does not meet quest rules' };
+  }
+  return { ok: true };
+}

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -10,6 +10,7 @@ beforeAll(async () => {
   ({ default: app } = await import('../server.js'));
   ({ default: db } = await import('../db.js'));
   try { await db.exec("ALTER TABLE quests ADD COLUMN code TEXT;"); } catch {}
+  try { await db.exec("ALTER TABLE quests ADD COLUMN requirement TEXT;"); } catch {}
   await db.exec(`CREATE TABLE IF NOT EXISTS tier_multipliers (
       tier TEXT PRIMARY KEY,
       multiplier REAL,

--- a/tests/submitProof.test.js
+++ b/tests/submitProof.test.js
@@ -1,0 +1,50 @@
+import request from 'supertest';
+import { jest } from '@jest/globals';
+
+let app, db;
+
+beforeAll(async () => {
+  process.env.SQLITE_FILE = ':memory:';
+  process.env.NODE_ENV = 'test';
+  process.env.X_TARGET_TWEET_URL = 'https://x.com/7goldencowries/status/1';
+  process.env.X_REQUIRED_HASHTAG = '#7GC';
+  process.env.X_TARGET_HANDLE = 'alice';
+  process.env.TWITTER_CONSUMER_KEY = 'x';
+  process.env.TWITTER_CONSUMER_SECRET = 'y';
+  ({ default: app } = await import('../server.js'));
+  ({ default: db } = await import('../db.js'));
+  try { await db.exec('ALTER TABLE quests ADD COLUMN requirement TEXT'); } catch {}
+  await db.run("INSERT INTO quests (id, title, xp, requirement, active) VALUES ('q1','Tweet Quest',10,'x_follow',1)");
+});
+
+afterAll(async () => {
+  await db.close();
+});
+
+describe('submit-proof flow', () => {
+  test('valid proof awards claim', async () => {
+    const agent = request.agent(app);
+    await agent.post('/api/session/bind-wallet').send({ wallet: 'w1' });
+    await db.run("UPDATE users SET twitter_username='alice' WHERE wallet='w1'");
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ html: `<blockquote><a href='https://x.com/7goldencowries/status/1'>Q</a> #7GC</blockquote>` }) });
+    const url = 'https://x.com/alice/status/1';
+    let res = await agent.post('/api/quests/submit-proof?wallet=w1').send({ questId: 'q1', url });
+    expect(res.body.status).toBe('verified');
+    res = await agent.post('/api/quests/claim?wallet=w1').send({ questId: 'q1' });
+    expect(res.body.ok).toBe(true);
+    const u = await db.get('SELECT xp FROM users WHERE wallet=?', 'w1');
+    expect(u.xp).toBeGreaterThan(0);
+  });
+
+  test('invalid proof prevents claim', async () => {
+    const agent = request.agent(app);
+    await agent.post('/api/session/bind-wallet').send({ wallet: 'w2' });
+    await db.run("UPDATE users SET twitter_username='alice' WHERE wallet='w2'");
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ html: '<blockquote>no match</blockquote>' }) });
+    const url = 'https://x.com/alice/status/2';
+    let res = await agent.post('/api/quests/submit-proof?wallet=w2').send({ questId: 'q1', url });
+    expect(res.body.status).toBe('rejected');
+    res = await agent.post('/api/quests/claim?wallet=w2').send({ questId: 'q1' });
+    expect(res.body.needProof).toBe(true);
+  });
+});

--- a/tests/twitterProof.test.js
+++ b/tests/twitterProof.test.js
@@ -1,0 +1,33 @@
+import { jest } from '@jest/globals';
+import { parseTweetUrl, verifyTwitterProof } from '../lib/twitterProof.js';
+
+describe('twitter proof helpers', () => {
+  test('parses tweet URLs', () => {
+    expect(parseTweetUrl('https://x.com/test/status/12345')).toEqual({ username: 'test', tweetId: '12345' });
+    expect(parseTweetUrl('https://twitter.com/abc/status/999')).toEqual({ username: 'abc', tweetId: '999' });
+    expect(parseTweetUrl('https://x.com/abc/')).toBeNull();
+  });
+
+  test('verifies by quote and hashtag', async () => {
+    process.env.X_TARGET_TWEET_URL = 'https://x.com/7goldencowries/status/1';
+    process.env.X_REQUIRED_HASHTAG = '#7GC';
+    process.env.X_TARGET_HANDLE = 'tester';
+    const user = { twitter_username: 'Tester' };
+    const url = 'https://x.com/Tester/status/1';
+    const fakeFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ html: `<blockquote><a href="https://x.com/7goldencowries/status/1">Quote</a> #7GC</blockquote>` })
+    });
+    const ok = await verifyTwitterProof({ user, quest: {}, url }, fakeFetch);
+    expect(ok.ok).toBe(true);
+    expect(fakeFetch).toHaveBeenCalled();
+  });
+
+  test('rejects when username mismatches', async () => {
+    const user = { twitter_username: 'alice' };
+    const url = 'https://x.com/bob/status/2';
+    const fakeFetch = jest.fn();
+    const res = await verifyTwitterProof({ user, quest: {}, url }, fakeFetch);
+    expect(res.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add quest_proofs table and env settings for X tweet verification
- implement verifyTwitterProof with oEmbed/HTML heuristics
- expose POST /api/quests/submit-proof and require verified proof on claim

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bba3997004832b9dad150f1ec90532