### PR TITLE
Add proof-gated Twitter quests with idempotent migrations

### DIFF
--- a/lib/ensureQuestsSchema.js
+++ b/lib/ensureQuestsSchema.js
@@ -5,9 +5,13 @@ async function hasColumn(table, name) {
   return cols.some(c => c.name === name);
 }
 
-async function addColumnIfMissing(table, name, typeAndDefaultSql) {
-  if (!(await hasColumn(table, name))) {
-    await db.run(`ALTER TABLE ${table} ADD COLUMN ${name} ${typeAndDefaultSql}`);
+async function addColumnIfMissing(table, name, type) {
+  const cols = await db.all(`PRAGMA table_info(${table})`);
+  if (!cols.some(c => c.name === name)) {
+    let t = String(type || "");
+    if (t.toUpperCase().startsWith(name.toUpperCase())) t = t.slice(name.length).trim();
+    t = t.replace(/DEFAULT.+$/i, "").trim();
+    await db.run(`ALTER TABLE ${table} ADD COLUMN ${name} ${t}`);
   }
 }
 
@@ -31,20 +35,31 @@ export async function ensureQuestsSchema() {
   `);
 
   // 2) Columns that might be missing on older DBs (ONLY constant defaults here)
-  await addColumnIfMissing("quests", "description", `TEXT DEFAULT ''`);
-  await addColumnIfMissing("quests", "category", `TEXT DEFAULT 'All'`);
-  await addColumnIfMissing("quests", "kind", `TEXT DEFAULT 'link'`);
-  await addColumnIfMissing("quests", "url", `TEXT DEFAULT ''`);
-  await addColumnIfMissing("quests", "xp", `INTEGER DEFAULT 0`);
-  await addColumnIfMissing("quests", "active", `INTEGER DEFAULT 1`);
-  await addColumnIfMissing("quests", "sort", `INTEGER DEFAULT 0`);
+  await addColumnIfMissing("quests", "description", `TEXT`);
+  await addColumnIfMissing("quests", "category", `TEXT`);
+  await addColumnIfMissing("quests", "kind", `TEXT`);
+  await addColumnIfMissing("quests", "url", `TEXT`);
+  await addColumnIfMissing("quests", "xp", `INTEGER`);
+  await addColumnIfMissing("quests", "active", `INTEGER`);
+  await addColumnIfMissing("quests", "sort", `INTEGER`);
   await addColumnIfMissing("quests", "createdAt", `INTEGER`);
   await addColumnIfMissing("quests", "updatedAt", `INTEGER`);
   await addColumnIfMissing("quests", "code", `TEXT`);
+  await addColumnIfMissing("quests", "requirement", `TEXT`);
   await db.run("CREATE UNIQUE INDEX IF NOT EXISTS idx_quests_code ON quests(code)");
 
   // 3) Backfill timestamps in a separate step (expressions are OK in UPDATE)
   await db.run(`UPDATE quests SET createdAt = COALESCE(createdAt, strftime('%s','now'))`);
   await db.run(`UPDATE quests SET updatedAt = COALESCE(updatedAt, createdAt)`);
+  await db.run(`
+    UPDATE quests SET description = COALESCE(description, '');
+    UPDATE quests SET category    = COALESCE(category, 'All');
+    UPDATE quests SET kind        = COALESCE(kind, 'link');
+    UPDATE quests SET url         = COALESCE(url, '');
+    UPDATE quests SET xp          = COALESCE(xp, 0);
+    UPDATE quests SET active      = COALESCE(active, 1);
+    UPDATE quests SET sort        = COALESCE(sort, 0);
+    UPDATE quests SET requirement = COALESCE(requirement, 'none');
+  `);
 }
 

--- a/tests/submitProof.test.js
+++ b/tests/submitProof.test.js
@@ -6,15 +6,12 @@ let app, db;
 beforeAll(async () => {
   process.env.SQLITE_FILE = ':memory:';
   process.env.NODE_ENV = 'test';
-  process.env.X_TARGET_TWEET_URL = 'https://x.com/7goldencowries/status/1';
-  process.env.X_REQUIRED_HASHTAG = '#7GC';
-  process.env.X_TARGET_HANDLE = 'alice';
   process.env.TWITTER_CONSUMER_KEY = 'x';
   process.env.TWITTER_CONSUMER_SECRET = 'y';
   ({ default: app } = await import('../server.js'));
   ({ default: db } = await import('../db.js'));
-  try { await db.exec('ALTER TABLE quests ADD COLUMN requirement TEXT'); } catch {}
   await db.run("INSERT INTO quests (id, title, xp, requirement, active) VALUES ('q1','Tweet Quest',10,'x_follow',1)");
+  await db.run("INSERT INTO quests (id, title, xp, requirement, active) VALUES ('q2','Basic Quest',5,'none',1)");
 });
 
 afterAll(async () => {
@@ -25,26 +22,46 @@ describe('submit-proof flow', () => {
   test('valid proof awards claim', async () => {
     const agent = request.agent(app);
     await agent.post('/api/session/bind-wallet').send({ wallet: 'w1' });
-    await db.run("UPDATE users SET twitter_username='alice' WHERE wallet='w1'");
-    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ html: `<blockquote><a href='https://x.com/7goldencowries/status/1'>Q</a> #7GC</blockquote>` }) });
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ html: '<blockquote class="twitter-tweet"></blockquote>' }) });
     const url = 'https://x.com/alice/status/1';
     let res = await agent.post('/api/quests/submit-proof?wallet=w1').send({ questId: 'q1', url });
     expect(res.body.status).toBe('verified');
     res = await agent.post('/api/quests/claim?wallet=w1').send({ questId: 'q1' });
+    expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
     const u = await db.get('SELECT xp FROM users WHERE wallet=?', 'w1');
     expect(u.xp).toBeGreaterThan(0);
   });
 
-  test('invalid proof prevents claim', async () => {
+  test('invalid URL proof rejected and claim blocked', async () => {
     const agent = request.agent(app);
     await agent.post('/api/session/bind-wallet').send({ wallet: 'w2' });
-    await db.run("UPDATE users SET twitter_username='alice' WHERE wallet='w2'");
-    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ html: '<blockquote>no match</blockquote>' }) });
-    const url = 'https://x.com/alice/status/2';
+    global.fetch = jest.fn();
+    const url = 'https://x.com/alice/status/abc';
     let res = await agent.post('/api/quests/submit-proof?wallet=w2').send({ questId: 'q1', url });
     expect(res.body.status).toBe('rejected');
     res = await agent.post('/api/quests/claim?wallet=w2').send({ questId: 'q1' });
-    expect(res.body.needProof).toBe(true);
+    expect(res.status).toBe(403);
+  });
+
+  test('claim without proof is forbidden for x quests', async () => {
+    const agent = request.agent(app);
+    await agent.post('/api/session/bind-wallet').send({ wallet: 'w3' });
+    const res = await agent.post('/api/quests/claim?wallet=w3').send({ questId: 'q1' });
+    expect(res.status).toBe(403);
+  });
+
+  test('non-x quest can be claimed without proof', async () => {
+    const agent = request.agent(app);
+    await agent.post('/api/session/bind-wallet').send({ wallet: 'w4' });
+    const res = await agent.post('/api/quests/claim?wallet=w4').send({ questId: 'q2' });
+    expect(res.status).toBe(200);
+    const u = await db.get('SELECT xp FROM users WHERE wallet=?', 'w4');
+    expect(u.xp).toBeGreaterThan(0);
+  });
+
+  test('legacy complete route removed', async () => {
+    const res = await request(app).post('/api/quests/complete?wallet=w1').send({ questId: 'q1' });
+    expect(res.status).toBe(404);
   });
 });


### PR DESCRIPTION
## Summary
- make schema migrations idempotent and add quest requirements & proof tracking
- add Twitter proof submission/lookup endpoints and gate XP claims on verified proof
- expand tests for proof verification and quest claiming rules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbed5d6044832b8ba3304d3d136089