### PR TITLE
feat: manual quest proof submission endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,6 +11,7 @@ import db from './db.js';
 import discordAuth from './routes/discordAuth.js';
 import questRoutes from './routes/questRoutes.js';
 import adminRoutes from './routes/adminRoutes.js';
+import proofRoutes from './routes/proofRoutes.js';
 
 const app = express();
 
@@ -202,6 +203,7 @@ app.get('/api/profile', async (req, res) => {
 /* ---------- Routes ---------- */
 app.use('/auth', discordAuth);
 app.use('/api/quest', questRoutes);
+app.use('/api/proofs', proofRoutes);
 app.use('/api/admin', adminRoutes); // seeding utilities
 
 /* ---------- Start ---------- */

--- a/routes/proofRoutes.js
+++ b/routes/proofRoutes.js
@@ -1,0 +1,62 @@
+import express from "express";
+import db from "../db.js";
+import { awardQuest } from "../lib/quests.js";
+import { delCache } from "../utils/cache.js";
+
+const router = express.Router();
+
+router.post("/", async (req, res) => {
+  try {
+    const quest_id = req.body?.quest_id ?? req.body?.questId;
+    const wallet = String(req.body?.wallet || "").trim();
+    const url = String(req.body?.url || "").trim();
+    if (!quest_id || !wallet || !url) {
+      return res.status(400).json({ error: "bad-args" });
+    }
+
+    const quest = await db.get("SELECT id FROM quests WHERE id = ?", quest_id);
+    if (!quest) {
+      return res.status(404).json({ error: "quest-not-found" });
+    }
+
+    const existing = await db.get(
+      "SELECT id FROM quest_proofs WHERE wallet = ? AND quest_id = ?",
+      wallet,
+      quest_id
+    );
+    if (existing) {
+      return res.status(409).json({ error: "already-submitted" });
+    }
+
+    await db.run(
+      `INSERT INTO quest_proofs (quest_id, wallet, url, createdAt, updatedAt)
+       VALUES (?, ?, ?, datetime('now'), datetime('now'))`,
+      quest_id,
+      wallet,
+      url
+    );
+
+    await db.run(
+      `INSERT OR IGNORE INTO users (wallet, xp, tier, levelName, levelSymbol, levelProgress, nextXP, updatedAt)
+       VALUES (?, 0, 'Free', 'Shellborn', '🐚', 0, 10000, strftime('%Y-%m-%dT%H:%M:%fZ','now'))`,
+      wallet
+    );
+
+    const result = await awardQuest(wallet, quest_id);
+    delCache(`user:${wallet}`);
+    const row = await db.get("SELECT xp FROM users WHERE wallet = ?", wallet);
+    const newTotalXp = row?.xp ?? 0;
+
+    res.json({
+      ok: true,
+      quest_id,
+      xp: newTotalXp,
+      alreadyClaimed: result.already ? true : undefined,
+    });
+  } catch (e) {
+    console.error("manual proof submission error", e);
+    res.status(500).json({ error: "server-error" });
+  }
+});
+
+export default router;

--- a/server.js
+++ b/server.js
@@ -23,6 +23,7 @@ import usersRoutes from "./routes/usersRoutes.js";
 import socialRoutes from "./routes/socialRoutes.js";
 import adminRoutes from "./routes/adminRoutes.js";
 import runSqliteMigrations from "./db/migrateProofs.js";
+import proofRoutes from "./routes/proofRoutes.js";
 
 dotenv.config();
 const logger = winston.createLogger({ level: "info", transports: [new winston.transports.Console()], format: winston.format.combine(winston.format.timestamp(), winston.format.simple()) });
@@ -130,6 +131,7 @@ await ensureSchema();
 
 app.use(metaRoutes);
 app.use(questRoutes);
+app.use("/api/proofs", proofRoutes);
 app.use("/api/users", usersRoutes);
 app.use(userRoutes);
 app.use("/api/profile", profileRoutes);

--- a/tests/manualProof.test.js
+++ b/tests/manualProof.test.js
@@ -1,0 +1,40 @@
+import request from 'supertest';
+
+let app, db;
+
+beforeAll(async () => {
+  process.env.SQLITE_FILE = ':memory:';
+  process.env.NODE_ENV = 'test';
+  process.env.TWITTER_CONSUMER_KEY = 'x';
+  process.env.TWITTER_CONSUMER_SECRET = 'y';
+  ({ default: app } = await import('../server.js'));
+  ({ default: db } = await import('../db.js'));
+  await db.run("INSERT INTO quests (id, title, xp, active) VALUES ('q1','Manual Quest',25,1)");
+});
+
+afterAll(async () => {
+  await db.close();
+});
+
+describe('POST /api/proofs', () => {
+  test('stores proof and awards xp', async () => {
+    const res = await request(app)
+      .post('/api/proofs')
+      .send({ quest_id: 'q1', wallet: 'w1', url: 'https://example.com/proof' });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    const u = await db.get('SELECT xp FROM users WHERE wallet=?', 'w1');
+    expect(u.xp).toBe(25);
+    const p = await db.get('SELECT url FROM quest_proofs WHERE wallet=? AND quest_id=?', 'w1', 'q1');
+    expect(p.url).toBe('https://example.com/proof');
+  });
+
+  test('rejects duplicate submissions', async () => {
+    const res = await request(app)
+      .post('/api/proofs')
+      .send({ quest_id: 'q1', wallet: 'w1', url: 'https://example.com/proof2' });
+    expect(res.status).toBe(409);
+    const u = await db.get('SELECT xp FROM users WHERE wallet=?', 'w1');
+    expect(u.xp).toBe(25);
+  });
+});


### PR DESCRIPTION
## Summary
- add `/api/proofs` route for manual URL proof submissions
- update server to mount proof routes
- test manual proof flow and duplicate prevention

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc13324bdc832bb03297fa12644d7a