### PR TITLE
Patch: XP migration backfills only (preserve bonuses & multipliers)

### DIFF
--- a/db/backfillXP.js
+++ b/db/backfillXP.js
@@ -1,0 +1,19 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Backfill users.xp from completed_quests when xp is NULL or 0.
+ * Preserves any existing bonuses or multipliers.
+ * @param {import('sqlite').Database} db
+ */
+export async function backfillXP(db) {
+  console.log('XP backfill: preserving existing XP; only filling NULL/0');
+  const sqlPath = path.join(__dirname, '../migrations/2025-09-03_recompute_user_xp.sql');
+  const sql = fs.readFileSync(sqlPath, 'utf8');
+  await db.exec(sql);
+}
+
+export default backfillXP;

--- a/migrations/2025-09-03_recompute_user_xp.sql
+++ b/migrations/2025-09-03_recompute_user_xp.sql
@@ -1,8 +1,9 @@
--- Recompute XP totals for all users based on completed quests
+-- Backfill users.xp ONLY when missing, preserve existing bonuses & multipliers
 UPDATE users
 SET xp = (
   SELECT COALESCE(SUM(q.xp), 0)
   FROM completed_quests c
   JOIN quests q ON q.id = c.quest_id
   WHERE c.wallet = users.wallet
-);
+)
+WHERE (xp IS NULL OR xp = 0);

--- a/tests/xpBackfillMigration.test.js
+++ b/tests/xpBackfillMigration.test.js
@@ -1,0 +1,41 @@
+import sqlite3 from 'sqlite3';
+import { open } from 'sqlite';
+import { backfillXP } from '../db/backfillXP.js';
+
+describe('XP backfill migration', () => {
+  async function setupDB() {
+    const db = await open({ filename: ':memory:', driver: sqlite3.Database });
+    await db.exec(`CREATE TABLE users (wallet TEXT PRIMARY KEY, xp INTEGER);
+                   CREATE TABLE quests (id INTEGER PRIMARY KEY, xp INTEGER);
+                   CREATE TABLE completed_quests (wallet TEXT, quest_id INTEGER);`);
+    return db;
+  }
+
+  test('XP backfill preserves existing XP', async () => {
+    const db = await setupDB();
+    await db.exec(`INSERT INTO users (wallet, xp) VALUES ('W1', 500);
+                   INSERT INTO quests (id, xp) VALUES (1, 200);
+                   INSERT INTO completed_quests (wallet, quest_id) VALUES ('W1', 1);`);
+    await backfillXP(db);
+    let row = await db.get(`SELECT xp FROM users WHERE wallet='W1'`);
+    expect(row.xp).toBe(500);
+    await backfillXP(db); // idempotent second run
+    row = await db.get(`SELECT xp FROM users WHERE wallet='W1'`);
+    expect(row.xp).toBe(500);
+    await db.close();
+  });
+
+  test('XP backfill fills missing XP', async () => {
+    const db = await setupDB();
+    await db.exec(`INSERT INTO users (wallet, xp) VALUES ('W2', 0);
+                   INSERT INTO quests (id, xp) VALUES (1, 100), (2, 50);
+                   INSERT INTO completed_quests (wallet, quest_id) VALUES ('W2',1), ('W2',2);`);
+    await backfillXP(db);
+    let row = await db.get(`SELECT xp FROM users WHERE wallet='W2'`);
+    expect(row.xp).toBe(150);
+    await backfillXP(db); // idempotent second run
+    row = await db.get(`SELECT xp FROM users WHERE wallet='W2'`);
+    expect(row.xp).toBe(150);
+    await db.close();
+  });
+});


### PR DESCRIPTION
## Summary
- Patch user XP recompute migration to only fill NULL or zero XP values, preserving multipliers and referral bonuses
- Add `backfillXP` runner that logs its safe operation
- Test XP backfill to ensure existing XP is unchanged and missing XP is filled; rerunning migration is a no-op

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc316a9ef0832b8beaf7a58ddc8592