### PR TITLE
Fix missing timestamp column causing startup failure

### DIFF
--- a/db.js
+++ b/db.js
@@ -178,6 +178,12 @@ const initDB = async () => {
     );
   `);
 
+  // Ensure critical columns exist before creating indices (for older DBs)
+  await addColumnIfMissing("completed_quests", "timestamp", "TEXT");
+  await db.exec("UPDATE completed_quests SET timestamp = COALESCE(timestamp, datetime('now'))");
+  await addColumnIfMissing("subscriptions", "timestamp", "TEXT");
+  await db.exec("UPDATE subscriptions SET timestamp = COALESCE(timestamp, datetime('now'))");
+
   // --- Indices (speed up common lookups) ---
   await ensureIndex("idx_quests_active",    "ON quests(active)");
   await ensureIndex("idx_completed_wallet", "ON completed_quests(wallet)");

--- a/tests/timestampMigration.test.js
+++ b/tests/timestampMigration.test.js
@@ -1,0 +1,37 @@
+import sqlite3 from 'sqlite3';
+import { open } from 'sqlite';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+test('adds missing timestamp columns', async () => {
+  const tmp = path.join(os.tmpdir(), 'ts-migration.sqlite');
+  try { fs.unlinkSync(tmp); } catch {}
+
+  const pre = await open({ filename: tmp, driver: sqlite3.Database });
+  await pre.exec(`CREATE TABLE completed_quests (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      wallet TEXT,
+      quest_id TEXT
+    );
+    CREATE TABLE subscriptions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      wallet TEXT,
+      tier TEXT,
+      tonAmount REAL,
+      usdAmount REAL,
+      status TEXT
+    );`);
+  await pre.close();
+
+  process.env.SQLITE_FILE = tmp;
+  const { default: db } = await import('../db.js');
+
+  const cqCols = await db.all("PRAGMA table_info(completed_quests)");
+  const subCols = await db.all("PRAGMA table_info(subscriptions)");
+  expect(cqCols.some(c => c.name === 'timestamp')).toBe(true);
+  expect(subCols.some(c => c.name === 'timestamp')).toBe(true);
+
+  await db.close();
+  fs.unlinkSync(tmp);
+});


### PR DESCRIPTION
## Summary
- ensure `completed_quests` and `subscriptions` have a `timestamp` column before index creation
- add tests confirming timestamp migration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc54171ce0832ba44ff52e2edb010c