### PR TITLE
Handle missing status column in proof tables

### DIFF
--- a/db.js
+++ b/db.js
@@ -183,6 +183,8 @@ const initDB = async () => {
   await db.exec("UPDATE completed_quests SET timestamp = COALESCE(timestamp, datetime('now'))");
   await addColumnIfMissing("subscriptions", "timestamp", "TEXT");
   await db.exec("UPDATE subscriptions SET timestamp = COALESCE(timestamp, datetime('now'))");
+  await addColumnIfMissing("quest_proofs", "status", "TEXT");
+  await db.exec("UPDATE quest_proofs SET status = COALESCE(status, 'pending')");
 
   // --- Indices (speed up common lookups) ---
   await ensureIndex("idx_quests_active",    "ON quests(active)");

--- a/db/migrateProofs.js
+++ b/db/migrateProofs.js
@@ -16,8 +16,6 @@ export async function runSqliteMigrations() {
     updatedAt TEXT DEFAULT (datetime('now')),
     UNIQUE(wallet, quest_id)
   );`);
-  await db.exec(`CREATE INDEX IF NOT EXISTS idx_proofs_status ON proofs(status);`);
-
   // add missing columns without volatile defaults
   const cols = await db.all(`PRAGMA table_info(proofs);`);
   const names = new Set(cols.map(c => c.name));
@@ -27,11 +25,14 @@ export async function runSqliteMigrations() {
       await db.exec(`ALTER TABLE proofs ADD COLUMN ${name} ${type};`);
     }
   };
+  await ensure('status', "TEXT NOT NULL DEFAULT 'pending'");
   await ensure('reason', 'TEXT');
   await ensure('tweet_id', 'TEXT');
   await ensure('handle', 'TEXT');
   await ensure('createdAt', 'TEXT');
   await ensure('updatedAt', 'TEXT');
+
+  await db.exec(`CREATE INDEX IF NOT EXISTS idx_proofs_status ON proofs(status);`);
 }
 
 export default runSqliteMigrations;


### PR DESCRIPTION
## Summary
- add migration to backfill `status` in `quest_proofs`
- ensure `proofs.status` column exists before creating index

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc56471bdc832bad6ad53ea09c8dd3