### PR TITLE
feat: unify SQLite env configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@ SESSION_NAME=7gc.sid
 SESSIONS_DIR=/var/data
 
 # SQLite database file path
-SQLITE_FILE=/var/data/7gc.sqlite
+DATABASE_URL=/var/data/7go.sqlite
 
 # Telegram bot token and username for social quests
 TELEGRAM_BOT_TOKEN=

--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -4,7 +4,7 @@
 
 - NODE_ENV=production
 - SESSION_SECRET
-- SQLITE_FILE=/var/data/7gc.sqlite
+- DATABASE_URL=/var/data/7go.sqlite
 - SESSIONS_DIR=/var/data
 - CORS_ORIGINS=https://7goldencowries.com,https://www.7goldencowries.com,https://7goldencowries-frontend.vercel.app
 

--- a/db.js
+++ b/db.js
@@ -37,7 +37,7 @@ async function ensureUniqueIndex(name, sql) {
 }
 
 const initDB = async () => {
-  const DB_FILE = process.env.SQLITE_FILE || "/var/data/7gc.sqlite";
+  const DB_FILE = process.env.DATABASE_URL || "/var/data/7go.sqlite";
   try {
     fs.mkdirSync(path.dirname(DB_FILE), { recursive: true });
   } catch (e) {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start:prod": "NODE_ENV=production node server.js",
     "dev": "NODE_ENV=development node server.js",
     "render-start": "node server.js",
-    "migrate:quests": "sqlite3 $SQLITE_FILE < scripts/migrate-quests.sql",
+    "migrate:quests": "sqlite3 $DATABASE_URL < scripts/migrate-quests.sql",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "smoke": "node scripts/smoke.mjs"
   },

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -5,7 +5,7 @@ let app, db;
 beforeAll(async () => {
   process.env.TWITTER_CONSUMER_KEY = "x";
   process.env.TWITTER_CONSUMER_SECRET = "y";
-  process.env.SQLITE_FILE = ':memory:';
+  process.env.DATABASE_URL = ':memory:';
   process.env.NODE_ENV = 'test';
   ({ default: app } = await import('../server.js'));
   ({ default: db } = await import('../db.js'));

--- a/tests/awardQuest.test.js
+++ b/tests/awardQuest.test.js
@@ -1,7 +1,7 @@
 let db, awardQuest;
 
 beforeAll(async () => {
-  process.env.SQLITE_FILE = ':memory:';
+  process.env.DATABASE_URL = ':memory:';
   ({ default: db } = await import('../db.js'));
   ({ awardQuest } = await import('../lib/quests.js'));
   try { await db.exec("ALTER TABLE quests ADD COLUMN code TEXT;"); } catch {}

--- a/tests/manualProof.test.js
+++ b/tests/manualProof.test.js
@@ -3,7 +3,7 @@ import request from 'supertest';
 let app, db;
 
 beforeAll(async () => {
-  process.env.SQLITE_FILE = ':memory:';
+  process.env.DATABASE_URL = ':memory:';
   process.env.NODE_ENV = 'test';
   process.env.TWITTER_CONSUMER_KEY = 'x';
   process.env.TWITTER_CONSUMER_SECRET = 'y';

--- a/tests/proofClaimFlow.test.js
+++ b/tests/proofClaimFlow.test.js
@@ -3,7 +3,7 @@ import request from 'supertest';
 let app, db;
 
 beforeAll(async () => {
-  process.env.SQLITE_FILE = ':memory:';
+  process.env.DATABASE_URL = ':memory:';
   process.env.NODE_ENV = 'test';
   process.env.TWITTER_CONSUMER_KEY = 'x';
   process.env.TWITTER_CONSUMER_SECRET = 'y';

--- a/tests/questsCategory.test.js
+++ b/tests/questsCategory.test.js
@@ -3,7 +3,7 @@ import request from 'supertest';
 let app, db;
 
 beforeAll(async () => {
-  process.env.SQLITE_FILE = ':memory:';
+  process.env.DATABASE_URL = ':memory:';
   process.env.NODE_ENV = 'test';
   process.env.TWITTER_CONSUMER_KEY = 'x';
   process.env.TWITTER_CONSUMER_SECRET = 'y';

--- a/tests/sessionClaimTier2.test.js
+++ b/tests/sessionClaimTier2.test.js
@@ -3,7 +3,7 @@ import request from 'supertest';
 let app, db;
 
 beforeAll(async () => {
-  process.env.SQLITE_FILE = ':memory:';
+  process.env.DATABASE_URL = ':memory:';
   process.env.NODE_ENV = 'test';
   process.env.TWITTER_CONSUMER_KEY = 'x';
   process.env.TWITTER_CONSUMER_SECRET = 'y';

--- a/tests/submitProof.test.js
+++ b/tests/submitProof.test.js
@@ -4,7 +4,7 @@ import { jest } from '@jest/globals';
 let app, db, proofToken, mockFetch;
 
 beforeAll(async () => {
-  process.env.SQLITE_FILE = ':memory:';
+  process.env.DATABASE_URL = ':memory:';
   process.env.NODE_ENV = 'test';
   process.env.PROOF_SECRET = 'secret';
   process.env.TWITTER_CONSUMER_KEY = 'x';

--- a/tests/timestampMigration.test.js
+++ b/tests/timestampMigration.test.js
@@ -24,7 +24,7 @@ test('adds missing timestamp columns', async () => {
     );`);
   await pre.close();
 
-  process.env.SQLITE_FILE = tmp;
+  process.env.DATABASE_URL = tmp;
   const { default: db } = await import('../db.js');
 
   const cqCols = await db.all("PRAGMA table_info(completed_quests)");


### PR DESCRIPTION
## Summary
- use `DATABASE_URL` env var for SQLite path with default `/var/data/7go.sqlite`
- update docs, scripts, and tests to match

## Testing
- `npm test`

## Launch Checklist
- [ ] Render envs set (see ENV Expectations).
- [ ] DB seeded with production quests + URLs.
- [ ] Health endpoint green after deploy.
- [ ] Manual sanity: submit proof & claim on at least 2 quest types.
- [ ] Frontend cache-bust (Vercel redeploy) and verify UI navigation & states.


------
https://chatgpt.com/codex/tasks/task_e_68bc61be8dcc832b8dfb05bf9745e4f6