### PR TITLE
Launch wiring: quests Go/proofs/claim, socials connected UI, idempotent migrations, health check, referrals.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Provision a 1GB disk mounted at `/var/data`.
 
 ```bash
 curl -s $BACKEND/healthz
+curl -s $BACKEND/api/health/db
 ```
 
 ## Tests

--- a/routes/healthRoutes.js
+++ b/routes/healthRoutes.js
@@ -1,0 +1,24 @@
+import express from "express";
+import db from "../db.js";
+
+const router = express.Router();
+
+router.get("/api/health/db", async (_req, res) => {
+  try {
+    const tables = await db.all("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'");
+    const counts = {};
+    for (const t of tables) {
+      try {
+        const row = await db.get(`SELECT COUNT(*) AS c FROM ${t.name}`);
+        counts[t.name] = row.c;
+      } catch (e) {
+        counts[t.name] = null;
+      }
+    }
+    res.json({ ok: true, tables: tables.map(t => t.name), counts });
+  } catch (e) {
+    res.status(500).json({ ok: false, error: e.message });
+  }
+});
+
+export default router;

--- a/server.js
+++ b/server.js
@@ -24,6 +24,7 @@ import socialRoutes from "./routes/socialRoutes.js";
 import adminRoutes from "./routes/adminRoutes.js";
 import runSqliteMigrations from "./db/migrateProofs.js";
 import proofRoutes from "./routes/proofRoutes.js";
+import healthRoutes from "./routes/healthRoutes.js";
 
 dotenv.config();
 const logger = winston.createLogger({ level: "info", transports: [new winston.transports.Console()], format: winston.format.combine(winston.format.timestamp(), winston.format.simple()) });
@@ -146,6 +147,7 @@ app.use("/api/admin/referrals", referralAdminRoutes);
 app.use("/api/session", sessionRoutes);
 app.use("/auth", socialRoutes);
 app.use("/api/admin", adminRoutes);
+app.use(healthRoutes);
 
 const FRONTEND_URL =
   process.env.FRONTEND_URL ||

--- a/tests/healthDb.test.js
+++ b/tests/healthDb.test.js
@@ -1,0 +1,23 @@
+import request from 'supertest';
+
+let app, db;
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = ':memory:';
+  process.env.NODE_ENV = 'test';
+  process.env.TWITTER_CONSUMER_KEY = 'x';
+  process.env.TWITTER_CONSUMER_SECRET = 'y';
+  ({ default: app } = await import('../server.js'));
+  ({ default: db } = await import('../db.js'));
+});
+
+afterAll(async () => {
+  await db.close();
+});
+
+test('/api/health/db returns tables and counts', async () => {
+  const res = await request(app).get('/api/health/db');
+  expect(res.body.ok).toBe(true);
+  expect(Array.isArray(res.body.tables)).toBe(true);
+  expect(res.body.counts).toBeTruthy();
+});


### PR DESCRIPTION
## Summary
- add `/api/health/db` endpoint that enumerates tables and row counts
- wire route into server and document in README
- cover new health check with unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcba46f2b8832b8243fa514ebabc4e