### PR TITLE
Add referral redirect and streamline health check

### DIFF
--- a/routes/healthRoutes.js
+++ b/routes/healthRoutes.js
@@ -5,19 +5,10 @@ const router = express.Router();
 
 router.get("/api/health/db", async (_req, res) => {
   try {
-    const tables = await db.all("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'");
-    const counts = {};
-    for (const t of tables) {
-      try {
-        const row = await db.get(`SELECT COUNT(*) AS c FROM ${t.name}`);
-        counts[t.name] = row.c;
-      } catch (e) {
-        counts[t.name] = null;
-      }
-    }
-    res.json({ ok: true, tables: tables.map(t => t.name), counts });
+    await db.get("SELECT 1");
+    res.json({ ok: true });
   } catch (e) {
-    res.status(500).json({ ok: false, error: e.message });
+    res.status(500).json({ ok: false });
   }
 });
 

--- a/routes/refRedirectRoutes.js
+++ b/routes/refRedirectRoutes.js
@@ -1,0 +1,25 @@
+import express from "express";
+import db from "../db.js";
+
+const router = express.Router();
+
+router.get("/ref/:code", async (req, res) => {
+  try {
+    const code = String(req.params.code || "").trim();
+    if (!code) return res.status(404).json({ error: "Invalid code" });
+    const row = await db.get("SELECT wallet FROM users WHERE referral_code = ?", [code]);
+    if (!row) return res.status(404).json({ error: "Invalid code" });
+    res.cookie("ref", code, {
+      maxAge: 30 * 24 * 60 * 60 * 1000,
+      sameSite: "lax",
+      path: "/",
+    });
+    req.session.ref = code;
+    const redirectUrl = process.env.FRONTEND_URL || "/";
+    return res.redirect(302, redirectUrl);
+  } catch (e) {
+    return res.status(500).json({ error: "Internal error" });
+  }
+});
+
+export default router;

--- a/routes/usersRoutes.js
+++ b/routes/usersRoutes.js
@@ -14,7 +14,7 @@ router.get("/me", async (req, res) => {
   try {
     const wallet =
       getSessionWallet(req) || (req.query.wallet ? String(req.query.wallet) : null);
-    if (!wallet) return res.status(400).json({ error: "Missing wallet address" });
+    if (!wallet) return res.json({ anon: true });
 
     // ensure user row exists
     await db.run(

--- a/server.js
+++ b/server.js
@@ -25,6 +25,7 @@ import adminRoutes from "./routes/adminRoutes.js";
 import runSqliteMigrations from "./db/migrateProofs.js";
 import proofRoutes from "./routes/proofRoutes.js";
 import healthRoutes from "./routes/healthRoutes.js";
+import refRedirectRoutes from "./routes/refRedirectRoutes.js";
 
 dotenv.config();
 const logger = winston.createLogger({ level: "info", transports: [new winston.transports.Console()], format: winston.format.combine(winston.format.timestamp(), winston.format.simple()) });
@@ -148,6 +149,7 @@ app.use("/api/session", sessionRoutes);
 app.use("/auth", socialRoutes);
 app.use("/api/admin", adminRoutes);
 app.use(healthRoutes);
+app.use(refRedirectRoutes);
 
 const FRONTEND_URL =
   process.env.FRONTEND_URL ||

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -53,4 +53,9 @@ describe('API routes', () => {
     expect(res.body.tierLabel).toBe('Tier 1');
     expect(res.body.multiplier).toBeCloseTo(1.1);
   });
+
+  test('/api/users/me returns anon when wallet missing', async () => {
+    const res = await request(app).get('/api/users/me');
+    expect(res.body.anon).toBe(true);
+  });
 });

--- a/tests/healthDb.test.js
+++ b/tests/healthDb.test.js
@@ -15,9 +15,7 @@ afterAll(async () => {
   await db.close();
 });
 
-test('/api/health/db returns tables and counts', async () => {
+test('/api/health/db returns ok true', async () => {
   const res = await request(app).get('/api/health/db');
-  expect(res.body.ok).toBe(true);
-  expect(Array.isArray(res.body.tables)).toBe(true);
-  expect(res.body.counts).toBeTruthy();
+  expect(res.body).toEqual({ ok: true });
 });

--- a/tests/refRedirect.test.js
+++ b/tests/refRedirect.test.js
@@ -1,0 +1,25 @@
+import request from 'supertest';
+
+let app, db;
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = ':memory:';
+  process.env.NODE_ENV = 'test';
+  process.env.TWITTER_CONSUMER_KEY = 'x';
+  process.env.TWITTER_CONSUMER_SECRET = 'y';
+  ({ default: app } = await import('../server.js'));
+  ({ default: db } = await import('../db.js'));
+  await db.exec("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, wallet TEXT, referral_code TEXT);");
+  await db.run("INSERT INTO users (wallet, referral_code) VALUES ('w2','ABC123')");
+});
+
+afterAll(async () => {
+  if (db) await db.close();
+});
+
+test('/ref/:code sets cookie and redirects', async () => {
+  const res = await request(app).get('/ref/ABC123');
+  expect(res.status).toBe(302);
+  expect(res.headers['set-cookie'][0]).toMatch(/ref=ABC123/);
+  expect(res.headers.location).toBe('/');
+});


### PR DESCRIPTION
## Summary
- Return `{anon:true}` from `/api/users/me` when no wallet is bound
- Simplify `/api/health/db` to a minimal database check
- Add public `/ref/:code` redirect that stores referral cookie

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcbf298af4832b95eef3feffe0ec20