### PR TITLE
Refine quest proofs and leaderboard output

### DIFF
--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -44,18 +44,25 @@ describe('API routes', () => {
 
   test('leaderboard shows users', async () => {
     const res = await request(app).get('/api/leaderboard');
-    expect(res.body.top[0].wallet).toBe('w1');
+    expect(res.body.entries[0].wallet).toBe('w1');
+    expect(res.body.total).toBeGreaterThan(0);
   });
 
-  test('/api/users/me exposes tier and multiplier', async () => {
+  test('/api/users/me exposes subscription tier and socials', async () => {
     const res = await request(app).get('/api/users/me?wallet=w1');
-    expect(res.body.tier).toBe('tier1');
-    expect(res.body.tierLabel).toBe('Tier 1');
-    expect(res.body.multiplier).toBeCloseTo(1.1);
+    expect(res.body.subscriptionTier).toBe('tier1');
+    expect(res.body.level).toBeDefined();
+    expect(res.body.nextXP).toBeGreaterThan(0);
+    expect(res.body.socials).toBeDefined();
   });
 
   test('/api/users/me returns anon when wallet missing', async () => {
     const res = await request(app).get('/api/users/me');
     expect(res.body.anon).toBe(true);
+  });
+
+  test('health db endpoint works', async () => {
+    const res = await request(app).get('/api/health/db');
+    expect(res.body.ok).toBe(true);
   });
 });

--- a/tests/proofClaimFlow.test.js
+++ b/tests/proofClaimFlow.test.js
@@ -25,7 +25,7 @@ describe('proof then claim flow', () => {
       .post('/api/quests/qpc/proofs')
       .send({ url, vendor: 'twitter' });
     expect(res.body.ok).toBe(true);
-    expect(res.body.proof.url).toBe(url);
+    expect(res.body.proofStatus).toBe('pending');
     res = await agent.post('/api/quests/qpc/claim');
     expect(res.status).toBe(200);
     const u1 = await db.get('SELECT xp FROM users WHERE wallet=?', 'w1');

--- a/utils/tweet.js
+++ b/utils/tweet.js
@@ -1,0 +1,18 @@
+export function parseTweetId(url) {
+  try {
+    const u = new URL(url);
+    const host = u.hostname.toLowerCase();
+    if (!['twitter.com','www.twitter.com','x.com','www.x.com'].includes(host)) return null;
+    const parts = u.pathname.split('/').filter(Boolean);
+    if (parts.length >=3 && parts[1].toLowerCase() === 'status' && /^\d+$/.test(parts[2])) {
+      return parts[2];
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function isValidTweetUrl(url) {
+  return parseTweetId(url) !== null;
+}


### PR DESCRIPTION
## Summary
- add tweet URL validators for proof submissions
- auto-approve tweet_link proofs and upsert quest_proofs rows
- expose leaderboard entries with total count
- streamline /api/users/me with level info and socials

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcc641a788832bbf267114f846252f