### PR TITLE
feat: enable telegram & discord membership verification

### DIFF
--- a/server.js
+++ b/server.js
@@ -22,6 +22,8 @@ import sessionRoutes from "./routes/sessionRoutes.js";
 import usersRoutes from "./routes/usersRoutes.js";
 import socialRoutes from "./routes/socialRoutes.js";
 import adminRoutes from "./routes/adminRoutes.js";
+import questTelegramRoutes from "./routes/questTelegramRoutes.js";
+import questDiscordRoutes from "./routes/questDiscordRoutes.js";
 import runSqliteMigrations from "./db/migrateProofs.js";
 import proofRoutes from "./routes/proofRoutes.js";
 import healthRoutes from "./routes/healthRoutes.js";
@@ -103,6 +105,14 @@ app.use(
   })
 );
 
+// expose session wallet as req.user.wallet for convenience
+app.use((req, _res, next) => {
+  if (req.session?.wallet && !req.user) {
+    req.user = { wallet: req.session.wallet };
+  }
+  next();
+});
+
 app.get("/healthz", async (_req, res) => {
   try {
     await db.exec(
@@ -139,6 +149,8 @@ await ensureSchema();
 
 app.use(metaRoutes);
 app.use(questRoutes);
+app.use(questTelegramRoutes);
+app.use(questDiscordRoutes);
 app.use("/api/proofs", proofRoutes);
 app.use("/api/users", usersRoutes);
 app.use(userRoutes);

--- a/tests/questSocialVerify.test.js
+++ b/tests/questSocialVerify.test.js
@@ -1,0 +1,67 @@
+import request from 'supertest';
+import { jest } from '@jest/globals';
+
+let app, db, fetchMock;
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = ':memory:';
+  process.env.NODE_ENV = 'test';
+  process.env.TELEGRAM_BOT_TOKEN = '123:abc';
+  process.env.TELEGRAM_GROUP_ID = '-100123';
+  process.env.DISCORD_BOT_TOKEN = 'discordbot';
+  process.env.DISCORD_GUILD_ID = 'guild123';
+  process.env.TWITTER_CONSUMER_KEY = 'x';
+  process.env.TWITTER_CONSUMER_SECRET = 'y';
+
+  fetchMock = jest.fn();
+  jest.unstable_mockModule('node-fetch', () => ({ default: fetchMock }));
+
+  ({ default: app } = await import('../server.js'));
+  ({ default: db } = await import('../db.js'));
+  await db.run("ALTER TABLE users ADD COLUMN telegram_id TEXT").catch(() => {});
+  await db.run("ALTER TABLE users ADD COLUMN discord_id TEXT").catch(() => {});
+});
+
+afterAll(async () => {
+  await db.close();
+});
+
+test('telegram join group awards xp when member', async () => {
+  const agent = request.agent(app);
+  await agent.post('/api/session/bind-wallet').send({ wallet: 'w1' });
+  await db.run("INSERT INTO quests (id, code, title, xp, requirement, active) VALUES (1,'tg_join_group','Join TG',50,'tg_group_member',1)");
+  await db.run("UPDATE users SET telegram_id = ? WHERE wallet = ?", ['tg123', 'w1']);
+
+  fetchMock.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ result: { status: 'member' } })
+  });
+
+  const res = await agent
+    .post('/api/quests/telegram/join/verify')
+    .send({ target: 'group' });
+
+  expect(res.status).toBe(200);
+  expect(res.body.results[0].status).toBe('completed');
+  const row = await db.get('SELECT xp FROM users WHERE wallet=?', 'w1');
+  expect(row.xp).toBe(50);
+});
+
+test('discord guild verify awards xp', async () => {
+  const agent = request.agent(app);
+  await agent.post('/api/session/bind-wallet').send({ wallet: 'w2' });
+  await db.run("INSERT INTO quests (id, code, title, xp, requirement, active) VALUES (2,'JOIN_DISCORD','Join Discord',40,'join_discord',1)");
+  await db.run("UPDATE users SET discord_id = ? WHERE wallet = ?", ['dc123', 'w2']);
+
+  fetchMock.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: async () => ({})
+  });
+
+  const res = await agent.post('/api/quests/discord/join/verify');
+  expect(res.status).toBe(200);
+  expect(res.body.status).toBe('completed');
+  const row = await db.get('SELECT xp FROM users WHERE wallet=?', 'w2');
+  expect(row.xp).toBe(40);
+});


### PR DESCRIPTION
## Summary
- expose session wallet as req.user and mount Telegram/Discord verification routes
- add tests for Telegram and Discord quest verification

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcd020386c832bb7cd3a8473617860