### PR TITLE
harden profile defaults

### DIFF
--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,38 +1,98 @@
 import { useEffect, useState } from 'react';
 import { fetchJson } from '../lib/api';
 
+const DEFAULT_ME = {
+  anon: true,
+  wallet: null as string | null,
+  xp: 0,
+  level: 1,
+  levelSymbol: 'Shellborn',
+  nextXP: 100,
+  subscriptionTier: 'Free',
+  socials: {
+    twitterHandle: null as string | null,
+    telegramId: null as string | null,
+    discordId: null as string | null,
+    discordGuildMember: false,
+  },
+  referral_code: null as string | null,
+};
+
 export default function Profile() {
-  const [user, setUser] = useState<any | null>(null);
+  const [me, setMe] = useState<typeof DEFAULT_ME>(DEFAULT_ME);
   const [loaded, setLoaded] = useState(false);
+
+  async function loadMe() {
+    try {
+      const apiMe = await fetchJson('/api/users/me');
+      const merged = {
+        ...DEFAULT_ME,
+        ...apiMe,
+        socials: {
+          ...DEFAULT_ME.socials,
+          ...(apiMe?.socials ?? {}),
+        },
+      };
+      setMe(merged);
+    } finally {
+      setLoaded(true);
+    }
+  }
 
   useEffect(() => {
     let cancelled = false;
-    fetchJson('/api/users/me')
-      .then((data) => {
-        if (!cancelled) {
-          setUser(data);
-          setLoaded(true);
-        }
-      })
-      .catch((err) => {
-        if (!cancelled) {
-          setLoaded(true);
-        }
-      });
+    async function fetchAll() {
+      const wallet = localStorage.getItem('wallet');
+      if (wallet) {
+        try {
+          await fetchJson('/api/session/bind-wallet', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ wallet }),
+          });
+        } catch {}
+      }
+      if (!cancelled) {
+        await loadMe();
+      }
+    }
+    fetchAll();
+    function handleChange() {
+      fetchAll();
+    }
+    window.addEventListener('wallet:changed', handleChange);
     return () => {
       cancelled = true;
+      window.removeEventListener('wallet:changed', handleChange);
     };
   }, []);
 
-  if (!loaded) return null;
+  if (!loaded) {
+    return <div>Loading...</div>;
+  }
 
-  if (!user) {
-    return <div>Connect your wallet / Refresh</div>;
+  if (me.anon) {
+    return (
+      <div>
+        <p>Connect wallet to view your profile</p>
+        <button>Connect Wallet</button>
+      </div>
+    );
   }
 
   return (
     <div>
-      <h1>{user.name || 'Profile'}</h1>
+      <h1>Profile</h1>
+      <p>Wallet: {me.wallet ?? ''}</p>
+      <p>XP: {me.xp ?? 0}</p>
+      <p>Level: {me.level ?? 1}</p>
+      <p>Level Symbol: {me.levelSymbol ?? 'Shellborn'}</p>
+      <p>Next XP: {me.nextXP ?? 100}</p>
+      <p>Subscription: {me.subscriptionTier ?? 'Free'}</p>
+      <p>Twitter: {me.socials?.twitterHandle ?? 'N/A'}</p>
+      <p>Telegram: {me.socials?.telegramId ?? 'N/A'}</p>
+      <p>Discord: {me.socials?.discordId ?? 'N/A'}</p>
+      <p>Referral Code: {me.referral_code ?? 'N/A'}</p>
     </div>
   );
 }

--- a/routes/usersRoutes.js
+++ b/routes/usersRoutes.js
@@ -5,6 +5,27 @@ import { getSessionWallet } from "../utils/session.js";
 
 const router = express.Router();
 
+const DEFAULT_ME = {
+  anon: true,
+  wallet: null,
+  xp: 0,
+  level: 1,
+  levelSymbol: "Shellborn",
+  nextXP: 100,
+  subscriptionTier: "Free",
+  socials: {
+    twitterHandle: null,
+    telegramId: null,
+    discordId: null,
+    discordGuildMember: false,
+  },
+  referral_code: null,
+};
+
+function makeRefCode(id) {
+  return (id.toString(36) + Math.random().toString(36).slice(2, 6)).toUpperCase();
+}
+
 /**
  * GET /api/users/me
  * Reads wallet from session; falls back to ?wallet=.
@@ -14,7 +35,7 @@ router.get("/me", async (req, res) => {
   try {
     const wallet =
       getSessionWallet(req) || (req.query.wallet ? String(req.query.wallet) : null);
-    if (!wallet) return res.json({ anon: true });
+    if (!wallet) return res.json({ ...DEFAULT_ME });
 
     // ensure user row exists
     await db.run(
@@ -24,7 +45,7 @@ router.get("/me", async (req, res) => {
     );
 
     const row = await db.get(
-      `SELECT u.wallet, u.xp, u.tier, u.levelSymbol, u.nextXP,
+      `SELECT u.id, u.wallet, u.xp, u.tier, u.levelSymbol, u.nextXP,
               u.telegramId, u.discordId, u.discordGuildMember, u.referral_code,
               u.twitterHandle
          FROM users u
@@ -32,24 +53,38 @@ router.get("/me", async (req, res) => {
       wallet
     );
 
-    const xp = row?.xp || 0;
+    const xp = row?.xp ?? 0;
     const lvl = deriveLevel(xp);
+    const level = lvl.levelIndex ?? 1;
+    const levelSymbol = row?.levelSymbol ?? "Shellborn";
+    const nextXP = row?.nextXP ?? 100;
+    const subscriptionTier = row?.tier ?? "Free";
     const socials = {
-      twitter: row?.twitterHandle || null,
-      telegramId: row?.telegramId || null,
-      discordId: row?.discordId || null,
+      twitterHandle: row?.twitterHandle ?? null,
+      telegramId: row?.telegramId ?? null,
+      discordId: row?.discordId ?? null,
       discordGuildMember: !!row?.discordGuildMember,
     };
 
+    let referral_code = row?.referral_code ?? null;
+    if (!referral_code && row?.id) {
+      referral_code = makeRefCode(row.id);
+      await db.run(
+        `UPDATE users SET referral_code=?, updatedAt=strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE id=?`,
+        [referral_code, row.id],
+      );
+    }
+
     return res.json({
+      anon: false,
       wallet,
       xp,
-      level: lvl.levelName,
-      levelSymbol: row?.levelSymbol || '🐚',
-      nextXP: lvl.nextNeed,
-      subscriptionTier: row?.tier || 'Free',
+      level,
+      levelSymbol,
+      nextXP,
+      subscriptionTier,
       socials,
-      referral_code: row?.referral_code || null,
+      referral_code,
     });
   } catch (e) {
     console.error("GET /api/users/me error", e);

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -54,11 +54,28 @@ describe('API routes', () => {
     expect(res.body.level).toBeDefined();
     expect(res.body.nextXP).toBeGreaterThan(0);
     expect(res.body.socials).toBeDefined();
+    expect(res.body.referral_code).toBeTruthy();
   });
 
-  test('/api/users/me returns anon when wallet missing', async () => {
+  test('/api/users/me returns anon with defaults when wallet missing', async () => {
     const res = await request(app).get('/api/users/me');
-    expect(res.body.anon).toBe(true);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      anon: true,
+      wallet: null,
+      xp: 0,
+      level: 1,
+      levelSymbol: 'Shellborn',
+      nextXP: 100,
+      subscriptionTier: 'Free',
+      socials: {
+        twitterHandle: null,
+        telegramId: null,
+        discordId: null,
+        discordGuildMember: false,
+      },
+      referral_code: null,
+    });
   });
 
   test('health db endpoint works', async () => {


### PR DESCRIPTION
## Summary
- ensure `/api/users/me` always returns full profile shape with defaults
- add referral code backfill and normalize socials keys
- normalize Profile page data and handle wallet changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd2e306044832ba51adaa79b2756c2