### PR TITLE
Add /health endpoint alias

### DIFF
--- a/routes/healthRoutes.js
+++ b/routes/healthRoutes.js
@@ -3,9 +3,11 @@ import db from "../db.js";
 
 const router = express.Router();
 
-router.get("/api/health", (_req, res) => {
+const healthHandler = (_req, res) => {
   res.json({ ok: true, uptime: process.uptime(), timestamp: Date.now() });
-});
+};
+
+router.get(["/api/health", "/health"], healthHandler);
 
 router.get("/api/health/db", async (_req, res) => {
   try {

--- a/tests/healthDb.test.js
+++ b/tests/healthDb.test.js
@@ -19,3 +19,8 @@ test('/api/health/db returns ok true', async () => {
   const res = await request(app).get('/api/health/db');
   expect(res.body).toEqual({ ok: true });
 });
+
+test('/health returns ok true', async () => {
+  const res = await request(app).get('/health');
+  expect(res.body.ok).toBe(true);
+});


### PR DESCRIPTION
## Summary
- expose `/health` as an alias of `/api/health` for uptime checks
- test the new `/health` route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd5c57ef98832bbbc77c7397b72e55