### PR TITLE
Finalize 7goldencowries: quests proofs, socials, referrals, leaderboard, profile fixes

### DIFF
--- a/config/progression.js
+++ b/config/progression.js
@@ -13,27 +13,28 @@ export const LEVELS = [
 export function deriveLevel(total = 0) {
   const xpTotal = Math.max(0, Number(total) || 0);
 
-  let levelIndex = -1;
-  for (const lvl of LEVELS) {
-    if (xpTotal >= lvl.need) levelIndex = lvl.id - 1;
-    else break;
-  }
-
-  if (levelIndex === -1) {
-    const next = LEVELS[0];
+  // Below first threshold: still considered first level
+  if (xpTotal < LEVELS[0].need) {
+    const nextNeed = LEVELS[0].need;
     return {
-      levelName: "Unranked",
-      levelIndex: 0,
+      levelName: LEVELS[0].key,
+      levelIndex: LEVELS[0].id,
       prevNeed: 0,
-      nextNeed: next.need,
-      progress: Math.min(xpTotal / next.need, 1),
+      nextNeed,
+      progress: Math.min(xpTotal / nextNeed, 1),
       xpTotal,
       maxXP: MAX_XP,
     };
   }
 
-  const current = LEVELS[levelIndex];
-  const next = LEVELS[levelIndex + 1];
+  // Find first level whose requirement exceeds current XP
+  let idx = 1;
+  for (; idx < LEVELS.length; idx++) {
+    if (xpTotal < LEVELS[idx].need) break;
+  }
+
+  const current = LEVELS[idx - 1];
+  const next = LEVELS[idx];
   const prevNeed = current.need;
   const nextNeed = next ? next.need : MAX_XP;
   const denom = nextNeed - prevNeed;

--- a/index.js
+++ b/index.js
@@ -165,7 +165,7 @@ app.get("/api/leaderboard", async (_req, res) => {
         twitter: u.twitterHandle || null,
         xp: u.xp,
         tier: u.tier || "Free",
-        name: level.levelName || "Unranked",
+        name: level.levelName || "Shellborn",
         progress: level.progress || 0, // 0..1
         badge: `/images/badges/${badgeSlug}`,
       };

--- a/lib/quests.js
+++ b/lib/quests.js
@@ -2,6 +2,8 @@
 import db from '../db.js';
 import { maybeCreditReferral } from '../utils/referrals.js';
 import { getTierMultiplier } from '../utils/tier.js';
+import { maybeRecordFirstQuest } from './referrals.js';
+import { delCache } from '../utils/cache.js';
 
 /**
  * Idempotently award a quest's XP to a wallet and record completion.
@@ -42,8 +44,14 @@ export async function awardQuest(wallet, questIdentifier) {
     "UPDATE users SET xp = COALESCE(xp, 0) + ?, updatedAt = strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE wallet = ?",
     xpGain, wallet
   );
-
   await maybeCreditReferral(wallet);
+  try {
+    const u = await db.get('SELECT id FROM users WHERE wallet = ?', wallet);
+    if (u?.id) await maybeRecordFirstQuest(u.id);
+  } catch {
+    /* ignore missing schema */
+  }
+  delCache('leaderboard');
 
   return { ok: true, baseXp, multiplier, xpGain, already: false, questId: qid };
 }

--- a/routes/questRoutes.js
+++ b/routes/questRoutes.js
@@ -324,9 +324,9 @@ router.post("/api/quests/:questId/proofs", async (req, res) => {
     const vendor = inferVendor(url);
     let status = "pending";
     const reqType = quest.requirement || "none";
-    if (reqType == "link" && url) {
+    if (["link", "join_telegram", "join_discord"].includes(reqType) && url) {
       status = "approved";
-    } else if (reqType == "tweet" && vendor == "twitter" && isValidTweetUrl(url)) {
+    } else if (["tweet", "retweet", "quote"].includes(reqType) && vendor == "twitter" && isValidTweetUrl(url)) {
       status = "approved";
     }
 

--- a/tests/deriveLevel.smoke.js
+++ b/tests/deriveLevel.smoke.js
@@ -1,6 +1,6 @@
 import assert from 'assert/strict';
 import { deriveLevel } from '../config/progression.js';
 
-assert.equal(deriveLevel(0).levelName, 'Unranked');
+assert.equal(deriveLevel(0).levelName, 'Shellborn');
 assert.equal(deriveLevel(250000).progress, 1);
 console.log('ok');

--- a/tests/deriveLevel.test.js
+++ b/tests/deriveLevel.test.js
@@ -1,9 +1,9 @@
 import { deriveLevel } from '../config/progression.js';
 
 describe('deriveLevel', () => {
-  test('handles negative xp', () => {
+  test('handles low or negative xp as Shellborn', () => {
     const lvl = deriveLevel(-5);
-    expect(lvl.levelName).toBe('Unranked');
+    expect(lvl.levelName).toBe('Shellborn');
     expect(lvl.progress).toBe(0);
   });
 


### PR DESCRIPTION
## Summary
- derive levels from 0 XP upwards and expose detailed progression info
- expand /api/users/me with socials, quest history, and level stats
- auto-approve additional quest proof types and award XP instantly
- compute cached leaderboard with level details and invalidate on claims
- credit referrers on first quest completion and clear leaderboard cache

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be1943eae0832bac81d95e5761c2c6