### PR TITLE
Fix: unify leaderboard endpoint shape

### DIFF
--- a/routes/leaderboardRoutes.js
+++ b/routes/leaderboardRoutes.js
@@ -10,7 +10,19 @@ const router = express.Router();
  * GET /api/leaderboard
  * Optional query: ?limit=50&offset=0
  * Response:
- *   { top: [{ rank, wallet, xp, tier, name, progress, twitter }] }
+ *   {
+ *     entries: [
+ *       {
+ *         rank,
+ *         wallet,
+ *         xp,
+ *         twitterHandle,
+ *         levelName,
+ *         progress,
+ *       },
+ *     ],
+ *     total: number,
+ *   }
  */
 router.get("/", async (req, res) => {
   try {


### PR DESCRIPTION
## Summary
- remove duplicate `/api/leaderboard` handler from `index.js`
- centralize leaderboard logic under `routes/leaderboardRoutes.js` returning `entries` and `total`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be1ed3f31c832b99498a86763edb5d