### PR TITLE
Invalidate user cache when awarding quests

### DIFF
--- a/lib/quests.js
+++ b/lib/quests.js
@@ -52,6 +52,7 @@ export async function awardQuest(wallet, questIdentifier) {
     /* ignore missing schema */
   }
   delCache('leaderboard');
+  delCache(`user:${wallet}`);
 
   return { ok: true, baseXp, multiplier, xpGain, already: false, questId: qid };
 }


### PR DESCRIPTION
## Summary
- clear cached user data after awarding quest XP to ensure fresh leaderboard and profile views

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68be54bdee1c832ba38958468839e8fc