### PR TITLE
Normalize user profile and quests API

### DIFF
--- a/routes/leaderboardRoutes.js
+++ b/routes/leaderboardRoutes.js
@@ -37,7 +37,7 @@ router.get("/", async (req, res) => {
     const offset = Math.max(0, parseInt(req.query.offset ?? "0", 10) || 0);
 
     const rows = await db.all(
-      `SELECT u.wallet, COALESCE(u.xp,0) AS xp, u.twitterHandle
+      `SELECT u.wallet, COALESCE(u.xp,0) AS xp, u.twitterHandle, u.tier
          FROM users u
         WHERE u.wallet IS NOT NULL
         ORDER BY COALESCE(u.xp,0) DESC, u.wallet ASC
@@ -54,10 +54,11 @@ router.get("/", async (req, res) => {
       return {
         wallet: r.wallet || "",
         xp: Number(r.xp ?? 0),
-        twitterHandle: r.twitterHandle || null,
+        twitterHandle: r.twitterHandle || undefined,
         levelName: lvl.levelName,
-        progress: lvl.progress,
+        progress: Math.min(1, Math.max(0, lvl.progress)),
         rank: offset + i + 1,
+        tier: r.tier || undefined,
       };
     });
 

--- a/routes/profileRoutes.js
+++ b/routes/profileRoutes.js
@@ -145,7 +145,15 @@ router.get("/", async (req, res) => {
       });
     }
     const data = await buildProfile(wallet);
-    res.json(data);
+    const p = data.profile;
+    res.json({
+      wallet: p.wallet,
+      levelName: p.levelName,
+      xp: p.xp,
+      levelProgress: p.levelProgress,
+      tier: p.tier,
+      twitterHandle: p.twitterHandle || undefined,
+    });
   } catch (e) {
     console.error("Profile route error:", e);
     // Typo fixed: previously used non-existent `njson`,
@@ -162,7 +170,15 @@ router.get("/:wallet", async (req, res) => {
     const wallet = resolveWallet(req);
     if (!wallet) return res.status(400).json({ error: "Missing wallet" });
     const data = await buildProfile(wallet);
-    res.json(data);
+    const p = data.profile;
+    res.json({
+      wallet: p.wallet,
+      levelName: p.levelName,
+      xp: p.xp,
+      levelProgress: p.levelProgress,
+      tier: p.tier,
+      twitterHandle: p.twitterHandle || undefined,
+    });
   } catch (e) {
     console.error("Profile route error:", e);
     res.status(500).json({ error: "Failed to load profile" });

--- a/routes/referralRoutes.js
+++ b/routes/referralRoutes.js
@@ -148,7 +148,7 @@ publicRouter.get("/stats", requireAuth, async (req, res) => {
 publicRouter.get("/:code", async (req, res) => {
   try {
     const code = String(req.params.code || "").trim();
-    if (!code) return res.json({ referrals: [] });
+    if (!code) return res.json({ entries: [] });
     const rows = await db.all(
       `SELECT u.wallet, COALESCE(u.xp,0) AS xp, r.created_at AS joinedAt
          FROM referrals r
@@ -158,7 +158,7 @@ publicRouter.get("/:code", async (req, res) => {
         LIMIT 100`,
       [code]
     );
-    res.json({ referrals: rows });
+    res.json({ entries: rows });
   } catch (e) {
     console.error("referrals/:code error", e);
     res.status(500).json({ error: "Internal error" });

--- a/routes/usersRoutes.js
+++ b/routes/usersRoutes.js
@@ -7,7 +7,7 @@ import { getSessionWallet } from "../utils/session.js";
 async function fetchHistory(wallet) {
   try {
     const rows = await db.all(
-      `SELECT id, quest_id AS questId, title, xp, completed_at
+      `SELECT id, quest_id, title, xp, completed_at
          FROM quest_history
         WHERE wallet = ?
         ORDER BY id DESC
@@ -16,7 +16,8 @@ async function fetchHistory(wallet) {
     );
     if (Array.isArray(rows))
       return rows.map((r) => ({
-        questId: r.questId,
+        id: r.id,
+        quest_id: r.quest_id,
         title: r.title,
         xp: r.xp,
         completed_at: r.completed_at,
@@ -26,7 +27,7 @@ async function fetchHistory(wallet) {
   }
   try {
     const rows = await db.all(
-      `SELECT c.rowid AS id, c.quest_id AS questId, q.title AS title, q.xp AS xp, c.timestamp AS completed_at
+      `SELECT c.rowid AS id, c.quest_id, q.title AS title, q.xp AS xp, c.timestamp AS completed_at
          FROM completed_quests c
          JOIN quests q ON q.id = c.quest_id
         WHERE c.wallet = ?
@@ -36,7 +37,8 @@ async function fetchHistory(wallet) {
     );
     if (Array.isArray(rows))
       return rows.map((r) => ({
-        questId: r.questId,
+        id: r.id,
+        quest_id: r.quest_id,
         title: r.title,
         xp: r.xp,
         completed_at: r.completed_at,

--- a/tests/questsCategory.test.js
+++ b/tests/questsCategory.test.js
@@ -30,9 +30,11 @@ describe('quests api', () => {
   });
 
   test('inserts proofs', async () => {
-    const res = await request(app)
+    const agent = request.agent(app);
+    await agent.post('/api/session/bind-wallet').send({ wallet: 'w1' });
+    const res = await agent
       .post('/api/quests/1/proofs')
-      .send({ wallet: 'w1', url: 'https://x.com/t/1' });
+      .send({ url: 'https://x.com/t/1' });
     expect(res.body.status).toBe('pending');
     const row = await db.get('SELECT wallet,vendor,url FROM quest_proofs WHERE quest_id=1 AND wallet=?', 'w1');
     expect(row.url).toBe('https://x.com/t/1');


### PR DESCRIPTION
## Summary
- normalize `/api/users/me` with flat quest history and socials
- refine quests endpoints: contract fields, proof submission with HEAD check, gated claims
- expose leaderboard tiers, idempotent wallet binding, referral lookup and profile summary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68beb24f8918832bb73883483bc26ccf