### PR TITLE
Enforce webhook secrets and expand health smoke coverage

### DIFF
--- a/config/env.js
+++ b/config/env.js
@@ -1,4 +1,15 @@
+import dotenv from "dotenv";
+
+let envLoaded = false;
+
+function ensureEnvLoaded() {
+  if (envLoaded) return;
+  envLoaded = true;
+  dotenv.config();
+}
+
 export function getRequiredEnv(name) {
+  ensureEnvLoaded();
   const value = process.env[name];
   if (typeof value === "string" && value.length > 0) {
     return value;


### PR DESCRIPTION
## Summary
- require webhook secrets at startup via a shared helper so misconfigurations fail fast
- add a Jest setup file to seed default secrets/DB config for tests and assert `/api/health` still reports DB status
- strengthen the Render smoke script to assert 200s on health endpoints before checking other APIs
- ensure `dotenv` loads before fetching required env vars so `.env` secrets are visible during route imports

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8a5a3491c832b89e796f2fbfc788a