### PR TITLE
Add final backend endpoints for wallet, subscription, referral flows

### DIFF
--- a/lib/grantXP.js
+++ b/lib/grantXP.js
@@ -1,0 +1,57 @@
+import db from "./db.js";
+import { deriveLevel } from "../config/progression.js";
+
+function resolveWallet(input) {
+  if (!input) return null;
+  if (typeof input === "string") return input;
+  if (typeof input === "object" && input.wallet) return String(input.wallet);
+  return null;
+}
+
+export async function grantXP(userOrWallet, delta) {
+  const wallet = resolveWallet(userOrWallet);
+  const amount = Math.max(0, Number(delta) || 0);
+  if (!wallet) {
+    return { delta: 0, total: 0 };
+  }
+
+  if (amount === 0) {
+    const row = await db.get("SELECT COALESCE(xp,0) AS xp FROM users WHERE wallet = ?", wallet);
+    const total = row?.xp ?? 0;
+    const level = deriveLevel(total);
+    return { delta: 0, total, level };
+  }
+
+  const timestamp = "strftime('%Y-%m-%dT%H:%M:%fZ','now')";
+  await db.run(
+    `INSERT OR IGNORE INTO users (wallet, xp, tier, levelName, levelSymbol, levelProgress, nextXP, updatedAt)
+       VALUES (?, 0, 'Free', 'Shellborn', '🐚', 0, 10000, ${timestamp})`,
+    wallet
+  );
+
+  const current = await db.get(
+    "SELECT COALESCE(xp,0) AS xp, levelName, levelProgress, nextXP FROM users WHERE wallet = ?",
+    wallet
+  );
+  const total = (current?.xp || 0) + amount;
+  const level = deriveLevel(total);
+
+  await db.run(
+    `UPDATE users
+        SET xp = ?,
+            levelName = ?,
+            levelProgress = ?,
+            nextXP = ?,
+            updatedAt = ${timestamp}
+      WHERE wallet = ?`,
+    total,
+    level.levelName,
+    level.progress,
+    level.nextNeed,
+    wallet
+  );
+
+  return { delta: amount, total, level };
+}
+
+export default grantXP;

--- a/routes/apiV1/index.js
+++ b/routes/apiV1/index.js
@@ -1,10 +1,12 @@
 import express from "express";
 import tokenSaleRoutes from "./tokenSaleRoutes.js";
 import subscriptionRoutes from "./subscriptionRoutes.js";
+import referralRoutes from "./referralRoutes.js";
 
 const router = express.Router();
 
 router.use("/token-sale", tokenSaleRoutes);
 router.use("/subscription", subscriptionRoutes);
+router.use("/referral", referralRoutes);
 
 export default router;

--- a/routes/apiV1/referralRoutes.js
+++ b/routes/apiV1/referralRoutes.js
@@ -1,0 +1,83 @@
+import express from "express";
+import db from "../../lib/db.js";
+import { getSessionWallet } from "../../utils/session.js";
+import { grantXP } from "../../lib/grantXP.js";
+import { crossSiteCookieOptions } from "../../utils/cookies.js";
+
+const router = express.Router();
+const REFERRAL_BONUS_QUEST_PREFIX = "REFERRAL_BONUS:";
+
+function normalizeCode(code) {
+  if (!code) return null;
+  const trimmed = String(code).trim();
+  const re = /^[A-Z0-9_-]{4,64}$/i;
+  return re.test(trimmed) ? trimmed : null;
+}
+
+router.post("/claim", async (req, res) => {
+  try {
+    const wallet = getSessionWallet(req);
+    if (!wallet) {
+      return res.status(401).json({ error: "wallet_required" });
+    }
+
+    const rawCode =
+      req.cookies?.referral_code ||
+      req.session?.referral_code ||
+      null;
+    const code = normalizeCode(rawCode);
+    if (!code) {
+      if (req.session?.referralClaimed) {
+        return res.json({ ok: true, xpDelta: 0 });
+      }
+      return res.status(400).json({ error: "referral_code_missing" });
+    }
+
+    const referrer = await db.get(
+      "SELECT wallet FROM users WHERE referral_code = ?",
+      code
+    );
+    if (!referrer?.wallet) {
+      res.clearCookie("referral_code", crossSiteCookieOptions());
+      req.session.referral_code = null;
+      return res.status(404).json({ error: "referrer_not_found" });
+    }
+
+    if (referrer.wallet === wallet) {
+      res.clearCookie("referral_code", crossSiteCookieOptions());
+      req.session.referral_code = null;
+      return res.status(400).json({ error: "self_referral" });
+    }
+
+    await db.run(
+      `UPDATE users SET referred_by = COALESCE(referred_by, ?), updatedAt = strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE wallet = ?`,
+      referrer.wallet,
+      wallet
+    );
+
+    const questId = `${REFERRAL_BONUS_QUEST_PREFIX}${code}`;
+    const inserted = await db.run(
+      `INSERT OR IGNORE INTO completed_quests (wallet, quest_id, timestamp)
+         VALUES (?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))`,
+      referrer.wallet,
+      questId
+    );
+
+    res.clearCookie("referral_code", crossSiteCookieOptions());
+    req.session.referral_code = null;
+
+    if (inserted.changes === 0) {
+      req.session.referralClaimed = true;
+      return res.json({ ok: true, xpDelta: 0 });
+    }
+
+    const result = await grantXP({ wallet: referrer.wallet }, 50);
+    req.session.referralClaimed = true;
+    return res.json({ ok: true, xpDelta: result.delta ?? 50 });
+  } catch (err) {
+    console.error("referral claim error", err);
+    return res.status(500).json({ error: "claim_failed" });
+  }
+});
+
+export default router;

--- a/routes/apiV1/subscriptionRoutes.js
+++ b/routes/apiV1/subscriptionRoutes.js
@@ -7,6 +7,8 @@ import db from "../../lib/db.js";
 import { getWebhookRateLimitOptions } from "../../config/rateLimits.js";
 import { getRequiredEnv } from "../../config/env.js";
 import { verifySubscriptionSession } from "../../lib/paymentProvider.js";
+import { getSessionWallet } from "../../utils/session.js";
+import { grantXP } from "../../lib/grantXP.js";
 
 const router = express.Router();
 
@@ -322,6 +324,57 @@ router.post("/callback", subscriptionCallbackLimiter, async (req, res) => {
   } catch (err) {
     console.error(`subscription callback error [${correlationId}]`, err);
     return res.status(500).json({ error: "callback_failed", correlationId });
+  }
+});
+
+const SUBSCRIPTION_CLAIM_QUEST_ID = "SUBSCRIPTION_CLAIM_BONUS";
+
+router.post("/claim", async (req, res) => {
+  try {
+    const wallet = getSessionWallet(req);
+    if (!wallet) {
+      return res.status(401).json({ error: "wallet_required" });
+    }
+
+    await db.run(
+      `INSERT OR IGNORE INTO users (wallet, xp, tier, levelName, levelSymbol, levelProgress, nextXP, updatedAt)
+         VALUES (?, 0, 'Free', 'Shellborn', '🐚', 0, 10000, strftime('%Y-%m-%dT%H:%M:%fZ','now'))`,
+      wallet
+    );
+
+    const inserted = await db.run(
+      `INSERT OR IGNORE INTO completed_quests (wallet, quest_id, timestamp)
+         VALUES (?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))`,
+      wallet,
+      SUBSCRIPTION_CLAIM_QUEST_ID
+    );
+
+    if (inserted.changes === 0) {
+      return res.json({ ok: true, xpDelta: 0 });
+    }
+
+    const result = await grantXP({ wallet }, 200);
+    return res.json({ ok: true, xpDelta: result.delta ?? 200 });
+  } catch (err) {
+    console.error("subscription claim error", err);
+    return res.status(500).json({ error: "claim_failed" });
+  }
+});
+
+router.get("/status", async (req, res) => {
+  try {
+    const wallet = getSessionWallet(req);
+    if (!wallet) {
+      return res.json({ tier: "Free" });
+    }
+    const row = await db.get(
+      "SELECT tier FROM users WHERE wallet = ?",
+      wallet
+    );
+    return res.json({ tier: row?.tier || "Free" });
+  } catch (err) {
+    console.error("subscription status error", err);
+    return res.status(500).json({ error: "status_failed" });
   }
 });
 

--- a/routes/refRedirectRoutes.js
+++ b/routes/refRedirectRoutes.js
@@ -1,5 +1,6 @@
 import express from "express";
 import db from "../lib/db.js";
+import { crossSiteCookieOptions } from "../utils/cookies.js";
 
 const router = express.Router();
 
@@ -9,13 +10,11 @@ router.get("/ref/:code", async (req, res) => {
     if (!code) return res.status(404).json({ error: "Invalid code" });
     const row = await db.get("SELECT wallet FROM users WHERE referral_code = ?", [code]);
     if (!row) return res.status(404).json({ error: "Invalid code" });
-    res.cookie("referral_code", code, {
-      maxAge: 2592000 * 1000,
-      httpOnly: true,
-      sameSite: "none",
-      secure: true,
-      path: "/",
-    });
+    res.cookie(
+      "referral_code",
+      code,
+      crossSiteCookieOptions({ maxAge: 2592000 * 1000 })
+    );
     req.session.referral_code = code;
     const redirectUrl =
       process.env.FRONTEND_URL || "https://7goldencowries.com";

--- a/routes/socialApiRoutes.js
+++ b/routes/socialApiRoutes.js
@@ -1,0 +1,96 @@
+import express from "express";
+import db from "../lib/db.js";
+import { getSessionWallet } from "../utils/session.js";
+
+const router = express.Router();
+
+const PROVIDERS = {
+  twitter: {
+    nullColumns: ["twitterHandle", "twitter_username", "twitter_id"],
+  },
+  telegram: {
+    nullColumns: ["telegramHandle", "telegram_username", "telegramId"],
+  },
+  discord: {
+    nullColumns: [
+      "discordHandle",
+      "discord_username",
+      "discordId",
+      "discord_id",
+      "discordAccessToken",
+      "discordRefreshToken",
+    ],
+    valueColumns: [
+      ["discordTokenExpiresAt", null],
+      ["discordGuildMember", 0],
+    ],
+  },
+};
+
+router.post("/:provider/unlink", async (req, res) => {
+  try {
+    const wallet = getSessionWallet(req);
+    if (!wallet) {
+      return res.status(401).json({ error: "wallet_required" });
+    }
+
+    const provider = String(req.params.provider || "").toLowerCase();
+    const config = PROVIDERS[provider];
+    if (!config) {
+      return res.status(400).json({ error: "unknown_provider" });
+    }
+
+    const user = await db.get(
+      "SELECT socials FROM users WHERE wallet = ?",
+      wallet
+    );
+    if (!user) {
+      return res.status(404).json({ error: "user_not_found" });
+    }
+
+    let socials = {};
+    if (user.socials) {
+      try {
+        const parsed = JSON.parse(user.socials);
+        if (parsed && typeof parsed === "object") {
+          socials = parsed;
+        }
+      } catch {
+        socials = {};
+      }
+    }
+
+    socials[provider] = { connected: false };
+    const socialsJson = JSON.stringify(socials);
+
+    const sets = [];
+    const params = [];
+
+    for (const column of config.nullColumns || []) {
+      sets.push(`${column} = NULL`);
+    }
+    for (const [column, value] of config.valueColumns || []) {
+      sets.push(`${column} = ?`);
+      params.push(value);
+    }
+
+    sets.push("socials = ?");
+    params.push(socialsJson);
+
+    sets.push("updatedAt = strftime('%Y-%m-%dT%H:%M:%fZ','now')");
+
+    params.push(wallet);
+
+    await db.run(
+      `UPDATE users SET ${sets.join(", ")} WHERE wallet = ?`,
+      params
+    );
+
+    return res.json({ ok: true });
+  } catch (err) {
+    console.error("social unlink error", err);
+    return res.status(500).json({ error: "unlink_failed" });
+  }
+});
+
+export default router;

--- a/tests/finalPolishRoutes.test.js
+++ b/tests/finalPolishRoutes.test.js
@@ -1,0 +1,110 @@
+import request from "supertest";
+
+let app;
+let db;
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = ":memory:";
+  process.env.NODE_ENV = "test";
+  process.env.TWITTER_CONSUMER_KEY = "test";
+  process.env.TWITTER_CONSUMER_SECRET = "secret";
+  process.env.FRONTEND_URL = "http://localhost:3000";
+  ({ default: app } = await import("../server.js"));
+  ({ default: db } = await import("../lib/db.js"));
+});
+
+afterAll(async () => {
+  if (db) {
+    await db.close();
+  }
+});
+
+describe("session disconnect", () => {
+  test("disconnect clears wallet from session", async () => {
+    const agent = request.agent(app);
+    await agent.post("/api/session/bind-wallet").send({ wallet: "wallet-disconnect" }).expect(200);
+
+    const before = await agent.get("/api/users/me");
+    expect(before.body.wallet).toBe("wallet-disconnect");
+
+    const disconnectRes = await agent.post("/api/session/disconnect");
+    expect(disconnectRes.body).toEqual({ ok: true });
+
+    const after = await agent.get("/api/users/me");
+    expect(after.body.wallet).toBeNull();
+  });
+});
+
+describe("subscription claim", () => {
+  test("awards xp once and is idempotent", async () => {
+    const agent = request.agent(app);
+    const wallet = "wallet-sub";
+    await agent.post("/api/session/bind-wallet").send({ wallet }).expect(200);
+
+    const first = await agent.post("/api/v1/subscription/claim");
+    expect(first.body).toMatchObject({ ok: true, xpDelta: 200 });
+
+    const second = await agent.post("/api/v1/subscription/claim");
+    expect(second.body).toMatchObject({ ok: true, xpDelta: 0 });
+
+    const row = await db.get("SELECT xp FROM users WHERE wallet = ?", wallet);
+    expect(row?.xp).toBe(200);
+  });
+});
+
+describe("referral claim", () => {
+  test("grants bonus to referrer and clears cookie", async () => {
+    await db.run(
+      `INSERT OR IGNORE INTO users (wallet, referral_code, xp, updatedAt)
+         VALUES ('referrer-wallet', 'REFCODE', 0, CURRENT_TIMESTAMP)`
+    );
+
+    const agent = request.agent(app);
+    await agent.get("/ref/REFCODE").expect(302);
+    await agent
+      .post("/api/session/bind-wallet")
+      .send({ wallet: "referred-wallet" })
+      .expect(200);
+
+    const first = await agent.post("/api/v1/referral/claim");
+    expect(first.body).toMatchObject({ ok: true, xpDelta: 50 });
+
+    const second = await agent.post("/api/v1/referral/claim");
+    expect(second.body).toMatchObject({ ok: true, xpDelta: 0 });
+
+    const referrer = await db.get(
+      "SELECT xp FROM users WHERE wallet = ?",
+      "referrer-wallet"
+    );
+    expect(referrer?.xp).toBe(50);
+  });
+});
+
+describe("social unlink", () => {
+  test("clears provider data and socials json", async () => {
+    const wallet = "social-wallet";
+    const socialsJson = JSON.stringify({ twitter: { connected: true, handle: "cowrie" } });
+    await db.run(
+      `INSERT OR REPLACE INTO users (wallet, socials, twitterHandle, twitter_username, twitter_id, updatedAt)
+         VALUES (?, ?, 'cowrie', 'cowrie', '123', CURRENT_TIMESTAMP)`,
+      wallet,
+      socialsJson
+    );
+
+    const agent = request.agent(app);
+    await agent.post("/api/session/bind-wallet").send({ wallet }).expect(200);
+
+    const res = await agent.post("/api/social/twitter/unlink");
+    expect(res.body).toEqual({ ok: true });
+
+    const row = await db.get(
+      "SELECT socials, twitterHandle, twitter_username, twitter_id FROM users WHERE wallet = ?",
+      wallet
+    );
+    expect(row.twitterHandle).toBeNull();
+    expect(row.twitter_username).toBeNull();
+    expect(row.twitter_id).toBeNull();
+    const updatedSocials = JSON.parse(row.socials);
+    expect(updatedSocials.twitter).toEqual({ connected: false });
+  });
+});

--- a/utils/cookies.js
+++ b/utils/cookies.js
@@ -1,0 +1,13 @@
+const isProd = process.env.NODE_ENV === 'production';
+
+export function crossSiteCookieOptions(overrides = {}) {
+  return {
+    httpOnly: true,
+    sameSite: isProd ? 'none' : 'lax',
+    secure: isProd,
+    path: '/',
+    ...overrides,
+  };
+}
+
+export default crossSiteCookieOptions;


### PR DESCRIPTION
## Summary
- configure CORS/cookie handling for production and mount the social API router
- add grantXP helper plus subscription/referral claim endpoints and session disconnect
- implement social unlink route and cover the new flows with integration tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c92065f178832b8b0dc5662e3292a5