### PR TITLE
Restore 10k→250k progression; unify progression across API & UI; keep PR#98 endpoints

### DIFF
--- a/config/progression.js
+++ b/config/progression.js
@@ -1,54 +1,40 @@
-export const MAX_XP = 250000;
-
 export const LEVELS = [
-  { id: 1, key: "Shellborn",        need: 10000 },
-  { id: 2, key: "Wave Seeker",      need: 30000 },
-  { id: 3, key: "Tide Whisperer",   need: 60000 },
-  { id: 4, key: "Current Binder",   need: 100000 },
-  { id: 5, key: "Pearl Bearer",     need: 150000 },
-  { id: 6, key: "Isle Champion",    need: 200000 },
-  { id: 7, key: "Cowrie Ascendant", need: 250000 },
+  { key: 'shellborn',        name: 'Shellborn',        symbol: '🐚', min: 0 },
+  { key: 'wave-seeker',      name: 'Wave Seeker',      symbol: '🌊', min: 10000 },
+  { key: 'tide-whisperer',   name: 'Tide Whisperer',   symbol: '🌀', min: 30000 },
+  { key: 'current-binder',   name: 'Current Binder',   symbol: '🪙', min: 60000 },
+  { key: 'pearl-bearer',     name: 'Pearl Bearer',     symbol: '🫧', min: 100000 },
+  { key: 'isle-champion',    name: 'Isle Champion',    symbol: '🏝️', min: 160000 },
+  { key: 'cowrie-ascendant', name: 'Cowrie Ascendant', symbol: '👑', min: 250000 },
 ];
 
-export function deriveLevel(total = 0) {
-  const xpTotal = Math.max(0, Number(total) || 0);
+export const MAX_XP = LEVELS[LEVELS.length - 1].min;
 
-  // Below first threshold: still considered first level
-  if (xpTotal < LEVELS[0].need) {
-    const nextNeed = LEVELS[0].need;
-    return {
-      levelName: LEVELS[0].key,
-      levelIndex: LEVELS[0].id,
-      prevNeed: 0,
-      nextNeed,
-      progress: Math.min(xpTotal / nextNeed, 1),
-      xpTotal,
-      maxXP: MAX_XP,
-    };
+export function deriveLevel(totalXPInput) {
+  const total = Math.max(0, Number(totalXPInput) || 0);
+  let i = LEVELS.length - 1;
+  for (let idx = 0; idx < LEVELS.length; idx += 1) {
+    const next = LEVELS[idx + 1];
+    if (!next || total < next.min) {
+      i = idx;
+      break;
+    }
   }
-
-  // Find first level whose requirement exceeds current XP
-  let idx = 1;
-  for (; idx < LEVELS.length; idx++) {
-    if (xpTotal < LEVELS[idx].need) break;
-  }
-
-  const current = LEVELS[idx - 1];
-  const next = LEVELS[idx];
-  const prevNeed = current.need;
-  const nextNeed = next ? next.need : MAX_XP;
-  const denom = nextNeed - prevNeed;
-  const progress = denom > 0
-    ? Math.max(0, Math.min((xpTotal - prevNeed) / denom, 1))
-    : 1;
+  const cur = LEVELS[i];
+  const next = LEVELS[i + 1] || null;
+  const span = next ? next.min - cur.min : 1;
+  const into = total - cur.min;
+  const progress = next ? Math.min(1, Math.max(0, into / span)) : 1;
 
   return {
-    levelName: current.key,
-    levelIndex: current.id,
-    prevNeed,
-    nextNeed,
+    totalXP: total,
+    levelName: cur.name,
+    levelSymbol: cur.symbol,
+    levelTier: cur.key,
     progress,
-    xpTotal,
-    maxXP: MAX_XP,
+    xpIntoLevel: into,
+    nextNeed: next ? span : into || 1,
   };
 }
+
+export default { LEVELS, deriveLevel, MAX_XP };

--- a/frontend/src/config/progression.js
+++ b/frontend/src/config/progression.js
@@ -1,0 +1,14 @@
+export const LEVELS = [
+  { key: 'shellborn',        name: 'Shellborn',        emoji: '🐚', min: 0 },
+  { key: 'wave-seeker',      name: 'Wave Seeker',      emoji: '🌊', min: 10000 },
+  { key: 'tide-whisperer',   name: 'Tide Whisperer',   emoji: '🌀', min: 30000 },
+  { key: 'current-binder',   name: 'Current Binder',   emoji: '🪙', min: 60000 },
+  { key: 'pearl-bearer',     name: 'Pearl Bearer',     emoji: '🫧', min: 100000 },
+  { key: 'isle-champion',    name: 'Isle Champion',    emoji: '🏝️', min: 160000 },
+  { key: 'cowrie-ascendant', name: 'Cowrie Ascendant', emoji: '👑', min: 250000 },
+];
+
+export const levelBadgeSrc = (levelName) => {
+  const base = String(levelName || 'Shellborn').toLowerCase().replace(/[^a-z0-9]+/g, '-');
+  return `/images/badges/level-${base}.png`;
+};

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,28 +1,74 @@
 import { useEffect, useState } from 'react';
 import { fetchJson } from '../lib/api';
 
-const DEFAULT_ME = {
-  wallet: null as string | null,
+type SocialRecord = {
+  connected: boolean;
+  handle?: string;
+  username?: string;
+  id?: string;
+};
+
+type ProfileState = {
+  wallet: string | null;
+  authed: boolean;
+  totalXP: number;
+  xp: number;
+  nextXP: number;
+  levelName: string;
+  levelSymbol: string;
+  levelTier: string;
+  levelProgress: number;
+  tier: string;
+  twitterHandle: string | null;
+  telegramHandle: string | null;
+  discordId: string | null;
+  socials: {
+    twitter: SocialRecord;
+    telegram: SocialRecord;
+    discord: SocialRecord;
+  };
+  questHistory: any[];
+  referralCount: number;
+};
+
+const DEFAULT_ME: ProfileState = {
+  wallet: null,
+  authed: false,
+  totalXP: 0,
   xp: 0,
-  level: 'Shellborn',
+  nextXP: 10000,
   levelName: 'Shellborn',
   levelSymbol: '🐚',
-  nextXP: 100,
-  twitterHandle: null as string | null,
-  telegramId: null as string | null,
-  discordId: null as string | null,
-  subscriptionTier: 'Free',
-  questHistory: [] as any[],
+  levelTier: 'shellborn',
+  levelProgress: 0,
+  tier: 'Free',
+  twitterHandle: null,
+  telegramHandle: null,
+  discordId: null,
+  socials: {
+    twitter: { connected: false },
+    telegram: { connected: false },
+    discord: { connected: false },
+  },
+  questHistory: [],
+  referralCount: 0,
 };
 
 export default function Profile() {
-  const [me, setMe] = useState<typeof DEFAULT_ME>(DEFAULT_ME);
+  const [me, setMe] = useState<ProfileState>(DEFAULT_ME);
   const [loaded, setLoaded] = useState(false);
 
   async function loadMe() {
     try {
       const apiMe = await fetchJson('/api/users/me');
-      setMe({ ...DEFAULT_ME, ...apiMe });
+      setMe({
+        ...DEFAULT_ME,
+        ...apiMe,
+        socials: {
+          ...DEFAULT_ME.socials,
+          ...(apiMe?.socials ?? {}),
+        },
+      });
     } finally {
       setLoaded(true);
     }
@@ -69,17 +115,28 @@ export default function Profile() {
     );
   }
 
+  const totalXpLabel = me.totalXP.toLocaleString();
+  const levelXpLabel = me.xp.toLocaleString();
+  const nextXpLabel = me.nextXP > 0 ? me.nextXP.toLocaleString() : '∞';
+  const progressPercent = `${(me.levelProgress * 100).toFixed(1)}%`;
+
   return (
     <div>
       <h1>Profile</h1>
-      <p>Wallet: {me.wallet ?? ''}</p>
-      <p>XP: {me.xp ?? 0}</p>
-      <p>Level: {me.level ?? 'Shellborn'}</p>
-      <p>Level Symbol: {me.levelSymbol ?? '🐚'}</p>
-      <p>Next XP: {me.nextXP ?? 100}</p>
-      <p>Subscription: {me.subscriptionTier ?? 'Free'}</p>
+      <p>Wallet: {me.wallet}</p>
+      <p>Authed: {me.authed ? 'Yes' : 'No'}</p>
+      <p>Total XP: {totalXpLabel}</p>
+      <p>
+        Level XP: {levelXpLabel} / {nextXpLabel}
+      </p>
+      <p>
+        Level: {me.levelSymbol} {me.levelName} ({me.levelTier})
+      </p>
+      <p>Progress: {progressPercent}</p>
+      <p>Tier: {me.tier}</p>
+      <p>Referral Count: {me.referralCount}</p>
       <p>Twitter: {me.twitterHandle ?? 'N/A'}</p>
-      <p>Telegram: {me.telegramId ?? 'N/A'}</p>
+      <p>Telegram: {me.telegramHandle ?? 'N/A'}</p>
       <p>Discord: {me.discordId ?? 'N/A'}</p>
     </div>
   );

--- a/lib/db.js
+++ b/lib/db.js
@@ -69,6 +69,9 @@ const initDB = async () => {
       levelSymbol TEXT DEFAULT '🐚',
       levelProgress REAL DEFAULT 0,
       nextXP INTEGER DEFAULT 10000,
+      referral_code TEXT,
+      referred_by TEXT,
+      socials TEXT DEFAULT '{}',
       twitterHandle TEXT,
       -- social / oauth fields
       telegramId TEXT,
@@ -80,7 +83,8 @@ const initDB = async () => {
       discordTokenExpiresAt INTEGER,
       discordGuildMember INTEGER DEFAULT 0,
       created_at DATETIME,
-      updatedAt DATETIME
+      updatedAt DATETIME,
+      UNIQUE(referral_code)
     );
 
     CREATE TABLE IF NOT EXISTS quests (
@@ -213,6 +217,7 @@ const initDB = async () => {
   await ensureIndex("idx_tokensale_wallet_time", "ON token_sale_contributions(wallet, created_at)");
 
   await ensureUniqueIndex("uq_users_wallet", "ON users(wallet)");
+  await ensureUniqueIndex("uq_users_referral_code", "ON users(referral_code)");
   await ensureIndex("idx_users_twitter", "ON users(twitterHandle)");
   await ensureIndex("idx_users_levelname", "ON users(levelName)");
 
@@ -285,6 +290,8 @@ const initDB = async () => {
   await addColumnIfMissing("users", "levelSymbol",           `levelSymbol TEXT DEFAULT '🐚'`);
   await addColumnIfMissing("users", "levelProgress",         `levelProgress REAL DEFAULT 0`);
   await addColumnIfMissing("users", "nextXP",                `nextXP INTEGER DEFAULT 10000`);
+  await addColumnIfMissing("users", "referral_code",         `referral_code TEXT`);
+  await addColumnIfMissing("users", "referred_by",           `referred_by TEXT`);
   await addColumnIfMissing("users", "twitterHandle",         `twitterHandle TEXT`);
   await addColumnIfMissing("users", "telegramId",            `telegramId TEXT`);
   await addColumnIfMissing("users", "telegramHandle",        `telegramHandle TEXT`);

--- a/lib/grantXP.js
+++ b/lib/grantXP.js
@@ -1,0 +1,59 @@
+import db from "./db.js";
+import { deriveLevel } from "../config/progression.js";
+
+function resolveWallet(input) {
+  if (!input) return null;
+  if (typeof input === "string") return input;
+  if (typeof input === "object" && input.wallet) return String(input.wallet);
+  return null;
+}
+
+export async function grantXP(userOrWallet, delta) {
+  const wallet = resolveWallet(userOrWallet);
+  const amount = Math.max(0, Number(delta) || 0);
+  if (!wallet) {
+    return { delta: 0, total: 0 };
+  }
+
+  if (amount === 0) {
+    const row = await db.get("SELECT COALESCE(xp,0) AS xp FROM users WHERE wallet = ?", wallet);
+    const total = row?.xp ?? 0;
+    const level = deriveLevel(total);
+    return { delta: 0, total, level };
+  }
+
+  const timestamp = "strftime('%Y-%m-%dT%H:%M:%fZ','now')";
+  await db.run(
+    `INSERT OR IGNORE INTO users (wallet, xp, tier, levelName, levelSymbol, levelProgress, nextXP, updatedAt)
+       VALUES (?, 0, 'Free', 'Shellborn', '🐚', 0, 10000, ${timestamp})`,
+    wallet
+  );
+
+  const current = await db.get(
+    "SELECT COALESCE(xp,0) AS xp FROM users WHERE wallet = ?",
+    wallet
+  );
+  const total = (current?.xp || 0) + amount;
+  const level = deriveLevel(total);
+
+  await db.run(
+    `UPDATE users
+        SET xp = ?,
+            levelName = ?,
+            levelSymbol = ?,
+            levelProgress = ?,
+            nextXP = ?,
+            updatedAt = ${timestamp}
+      WHERE wallet = ?`,
+    total,
+    level.levelName,
+    level.levelSymbol,
+    level.progress,
+    level.nextNeed,
+    wallet
+  );
+
+  return { delta: amount, total, level };
+}
+
+export default grantXP;

--- a/routes/apiV1/index.js
+++ b/routes/apiV1/index.js
@@ -1,10 +1,12 @@
 import express from "express";
 import tokenSaleRoutes from "./tokenSaleRoutes.js";
 import subscriptionRoutes from "./subscriptionRoutes.js";
+import referralRoutes from "./referralRoutes.js";
 
 const router = express.Router();
 
 router.use("/token-sale", tokenSaleRoutes);
 router.use("/subscription", subscriptionRoutes);
+router.use("/referral", referralRoutes);
 
 export default router;

--- a/routes/apiV1/referralRoutes.js
+++ b/routes/apiV1/referralRoutes.js
@@ -1,0 +1,90 @@
+import express from "express";
+import rateLimit from "express-rate-limit";
+import db from "../../lib/db.js";
+import { getSessionWallet } from "../../utils/session.js";
+import { grantXP } from "../../lib/grantXP.js";
+import { crossSiteCookieOptions } from "../../utils/cookies.js";
+
+const router = express.Router();
+const REFERRAL_BONUS_QUEST_PREFIX = "REFERRAL_BONUS:";
+const claimLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 20,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+function normalizeCode(code) {
+  if (!code) return null;
+  const trimmed = String(code).trim();
+  const re = /^[A-Z0-9_-]{4,64}$/i;
+  return re.test(trimmed) ? trimmed : null;
+}
+
+router.post("/claim", claimLimiter, async (req, res) => {
+  try {
+    const wallet = getSessionWallet(req);
+    if (!wallet) {
+      return res.status(401).json({ error: "wallet_required" });
+    }
+
+    const rawCode =
+      req.cookies?.referral_code ||
+      req.session?.referral_code ||
+      null;
+    const code = normalizeCode(rawCode);
+    if (!code) {
+      if (req.session?.referralClaimed) {
+        return res.json({ ok: true, xpDelta: 0 });
+      }
+      return res.status(400).json({ error: "referral_code_missing" });
+    }
+
+    const referrer = await db.get(
+      "SELECT wallet FROM users WHERE referral_code = ?",
+      code
+    );
+    if (!referrer?.wallet) {
+      res.clearCookie("referral_code", crossSiteCookieOptions());
+      req.session.referral_code = null;
+      return res.status(404).json({ error: "referrer_not_found" });
+    }
+
+    if (referrer.wallet === wallet) {
+      res.clearCookie("referral_code", crossSiteCookieOptions());
+      req.session.referral_code = null;
+      return res.status(400).json({ error: "self_referral" });
+    }
+
+    await db.run(
+      `UPDATE users SET referred_by = COALESCE(referred_by, ?), updatedAt = strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE wallet = ?`,
+      referrer.wallet,
+      wallet
+    );
+
+    const questId = `${REFERRAL_BONUS_QUEST_PREFIX}${code}`;
+    const inserted = await db.run(
+      `INSERT OR IGNORE INTO completed_quests (wallet, quest_id, timestamp)
+         VALUES (?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))`,
+      referrer.wallet,
+      questId
+    );
+
+    res.clearCookie("referral_code", crossSiteCookieOptions());
+    req.session.referral_code = null;
+
+    if (inserted.changes === 0) {
+      req.session.referralClaimed = true;
+      return res.json({ ok: true, xpDelta: 0 });
+    }
+
+    const result = await grantXP({ wallet: referrer.wallet }, 50);
+    req.session.referralClaimed = true;
+    return res.json({ ok: true, xpDelta: result.delta ?? 50 });
+  } catch (err) {
+    console.error("referral claim error", err);
+    return res.status(500).json({ error: "claim_failed" });
+  }
+});
+
+export default router;

--- a/routes/leaderboardRoutes.js
+++ b/routes/leaderboardRoutes.js
@@ -50,14 +50,21 @@ router.get("/", async (req, res) => {
       `SELECT COUNT(*) AS c FROM users WHERE wallet IS NOT NULL`
     );
     const entries = (rows || []).map((r, i) => {
-      const lvl = deriveLevel(r.xp || 0);
+      const totalXP = Number(r.xp ?? 0);
+      const lvl = deriveLevel(totalXP);
       const prog = lvl.progress > 1 ? lvl.progress / 100 : lvl.progress;
+      const clampedProgress = Math.min(1, Math.max(0, prog));
       return {
         wallet: r.wallet || "",
-        xp: Number(r.xp ?? 0),
+        totalXP,
+        xp: Math.max(0, lvl.xpIntoLevel ?? 0),
+        nextXP: lvl.nextNeed,
         twitterHandle: r.twitterHandle || r.twitter_username || undefined,
         levelName: lvl.levelName,
-        progress: Math.min(1, Math.max(0, prog)),
+        levelSymbol: lvl.levelSymbol,
+        levelTier: lvl.levelTier,
+        levelProgress: clampedProgress,
+        progress: clampedProgress,
         rank: offset + i + 1,
         tier: r.tier || undefined,
       };

--- a/routes/profileRoutes.js
+++ b/routes/profileRoutes.js
@@ -100,9 +100,11 @@ async function buildProfile(wallet) {
   );
 
   // Compute level info/fallbacks
-  const lvl = deriveLevel(u?.xp ?? 0);
+  const totalXP = u?.xp ?? 0;
+  const lvl = deriveLevel(totalXP);
   const levelName     = lvl.levelName;
-  const levelProgress = lvl.progress;
+  const levelProgress = Math.max(0, Math.min(1, lvl.progress ?? 0));
+  const xpIntoLevel   = Math.max(0, lvl.xpIntoLevel ?? 0);
   const nextXP        = lvl.nextNeed;
 
   // Merge links: prefer social_links table, then users.*Handle
@@ -117,9 +119,12 @@ async function buildProfile(wallet) {
   return {
     profile: {
       wallet: u?.wallet || wallet,
-      xp: u?.xp ?? 0,
+      totalXP,
+      xp: xpIntoLevel,
       tier: u?.tier || "Free",
       levelName,
+      levelSymbol: lvl.levelSymbol,
+      levelTier: lvl.levelTier,
       levelProgress,
       nextXP,
       twitterHandle:  u?.twitterHandle  || null,
@@ -149,7 +154,11 @@ router.get("/", async (req, res) => {
     res.json({
       wallet: p.wallet,
       levelName: p.levelName,
+      totalXP: p.totalXP,
       xp: p.xp,
+      nextXP: p.nextXP,
+      levelSymbol: p.levelSymbol,
+      levelTier: p.levelTier,
       levelProgress: p.levelProgress,
       tier: p.tier,
       twitterHandle: p.twitterHandle || undefined,
@@ -174,7 +183,11 @@ router.get("/:wallet", async (req, res) => {
     res.json({
       wallet: p.wallet,
       levelName: p.levelName,
+      totalXP: p.totalXP,
       xp: p.xp,
+      nextXP: p.nextXP,
+      levelSymbol: p.levelSymbol,
+      levelTier: p.levelTier,
       levelProgress: p.levelProgress,
       tier: p.tier,
       twitterHandle: p.twitterHandle || undefined,

--- a/routes/refRedirectRoutes.js
+++ b/routes/refRedirectRoutes.js
@@ -1,5 +1,6 @@
 import express from "express";
 import db from "../lib/db.js";
+import { crossSiteCookieOptions } from "../utils/cookies.js";
 
 const router = express.Router();
 
@@ -9,13 +10,11 @@ router.get("/ref/:code", async (req, res) => {
     if (!code) return res.status(404).json({ error: "Invalid code" });
     const row = await db.get("SELECT wallet FROM users WHERE referral_code = ?", [code]);
     if (!row) return res.status(404).json({ error: "Invalid code" });
-    res.cookie("referral_code", code, {
-      maxAge: 2592000 * 1000,
-      httpOnly: true,
-      sameSite: "none",
-      secure: true,
-      path: "/",
-    });
+    res.cookie(
+      "referral_code",
+      code,
+      crossSiteCookieOptions({ maxAge: 2592000 * 1000 })
+    );
     req.session.referral_code = code;
     const redirectUrl =
       process.env.FRONTEND_URL || "https://7goldencowries.com";

--- a/routes/socialApiRoutes.js
+++ b/routes/socialApiRoutes.js
@@ -1,0 +1,96 @@
+import express from "express";
+import db from "../lib/db.js";
+import { getSessionWallet } from "../utils/session.js";
+
+const router = express.Router();
+
+const PROVIDERS = {
+  twitter: {
+    nullColumns: ["twitterHandle", "twitter_username", "twitter_id"],
+  },
+  telegram: {
+    nullColumns: ["telegramHandle", "telegram_username", "telegramId"],
+  },
+  discord: {
+    nullColumns: [
+      "discordHandle",
+      "discord_username",
+      "discordId",
+      "discord_id",
+      "discordAccessToken",
+      "discordRefreshToken",
+    ],
+    valueColumns: [
+      ["discordTokenExpiresAt", null],
+      ["discordGuildMember", 0],
+    ],
+  },
+};
+
+router.post("/:provider/unlink", async (req, res) => {
+  try {
+    const wallet = getSessionWallet(req);
+    if (!wallet) {
+      return res.status(401).json({ error: "wallet_required" });
+    }
+
+    const provider = String(req.params.provider || "").toLowerCase();
+    const config = PROVIDERS[provider];
+    if (!config) {
+      return res.status(400).json({ error: "unknown_provider" });
+    }
+
+    const user = await db.get(
+      "SELECT socials FROM users WHERE wallet = ?",
+      wallet
+    );
+    if (!user) {
+      return res.status(404).json({ error: "user_not_found" });
+    }
+
+    let socials = {};
+    if (user.socials) {
+      try {
+        const parsed = JSON.parse(user.socials);
+        if (parsed && typeof parsed === "object") {
+          socials = parsed;
+        }
+      } catch {
+        socials = {};
+      }
+    }
+
+    socials[provider] = { connected: false };
+    const socialsJson = JSON.stringify(socials);
+
+    const sets = [];
+    const params = [];
+
+    for (const column of config.nullColumns || []) {
+      sets.push(`${column} = NULL`);
+    }
+    for (const [column, value] of config.valueColumns || []) {
+      sets.push(`${column} = ?`);
+      params.push(value);
+    }
+
+    sets.push("socials = ?");
+    params.push(socialsJson);
+
+    sets.push("updatedAt = strftime('%Y-%m-%dT%H:%M:%fZ','now')");
+
+    params.push(wallet);
+
+    await db.run(
+      `UPDATE users SET ${sets.join(", ")} WHERE wallet = ?`,
+      params
+    );
+
+    return res.json({ ok: true });
+  } catch (err) {
+    console.error("social unlink error", err);
+    return res.status(500).json({ error: "unlink_failed" });
+  }
+});
+
+export default router;

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -24,15 +24,19 @@ async function fetchUser(wallet, res) {
       user = await db.get("SELECT * FROM users WHERE wallet = ?", wallet);
     }
 
-    const { xp, tier, twitterHandle } = user;
-    const lvl = deriveLevel(xp);
+    const totalXP = user?.xp ?? 0;
+    const { tier, twitterHandle } = user;
+    const lvl = deriveLevel(totalXP);
     const data = {
-      xp,
+      totalXP,
+      xp: Math.max(0, lvl.xpIntoLevel ?? 0),
+      nextXP: lvl.nextNeed,
       tier,
       twitter: twitterHandle || null,
       levelName: lvl.levelName,
-      levelProgress: lvl.progress,
-      nextXP: lvl.nextNeed,
+      levelSymbol: lvl.levelSymbol,
+      levelTier: lvl.levelTier,
+      levelProgress: Math.max(0, Math.min(1, lvl.progress ?? 0)),
     };
     setCache(key, data, TTL);
     res.json(data);

--- a/tests/api.social.unlink.test.js
+++ b/tests/api.social.unlink.test.js
@@ -1,0 +1,27 @@
+import request from "supertest";
+
+let app;
+let db;
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = ":memory:";
+  process.env.NODE_ENV = "test";
+  process.env.FRONTEND_URL = "http://localhost:3000";
+  process.env.TWITTER_CONSUMER_KEY = "test";
+  process.env.TWITTER_CONSUMER_SECRET = "secret";
+  ({ default: app } = await import("../server.js"));
+  ({ default: db } = await import("../lib/db.js"));
+});
+
+afterAll(async () => {
+  if (db) {
+    await db.close();
+  }
+});
+
+describe("Social unlink", () => {
+  it("401 without session wallet", async () => {
+    const res = await request(app).post("/api/social/twitter/unlink");
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -31,7 +31,10 @@ describe('API routes', () => {
 
   test('returns user stats', async () => {
     const res = await request(app).get('/api/users/w1');
+    expect(res.body.totalXP).toBe(105);
     expect(res.body.xp).toBe(105);
+    expect(res.body.nextXP).toBe(10000);
+    expect(res.body.levelTier).toBe('shellborn');
   });
 
   test('leaderboard shows users', async () => {
@@ -51,6 +54,8 @@ describe('API routes', () => {
     const res = await request(app).get('/api/users/me');
     expect(res.status).toBe(200);
     expect(res.body.wallet).toBeNull();
+    expect(res.body.totalXP).toBe(0);
+    expect(res.body.levelTier).toBe('shellborn');
     expect(res.body.socials.twitter.connected).toBe(false);
   });
 

--- a/tests/api.v1.referral.claim.test.js
+++ b/tests/api.v1.referral.claim.test.js
@@ -1,0 +1,27 @@
+import request from "supertest";
+
+let app;
+let db;
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = ":memory:";
+  process.env.NODE_ENV = "test";
+  process.env.FRONTEND_URL = "http://localhost:3000";
+  process.env.TWITTER_CONSUMER_KEY = "test";
+  process.env.TWITTER_CONSUMER_SECRET = "secret";
+  ({ default: app } = await import("../server.js"));
+  ({ default: db } = await import("../lib/db.js"));
+});
+
+afterAll(async () => {
+  if (db) {
+    await db.close();
+  }
+});
+
+describe("Referral claim", () => {
+  it("401 without session wallet", async () => {
+    const res = await request(app).post("/api/v1/referral/claim");
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/api.v1.subscription.claim.test.js
+++ b/tests/api.v1.subscription.claim.test.js
@@ -1,0 +1,27 @@
+import request from "supertest";
+
+let app;
+let db;
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = ":memory:";
+  process.env.NODE_ENV = "test";
+  process.env.FRONTEND_URL = "http://localhost:3000";
+  process.env.TWITTER_CONSUMER_KEY = "test";
+  process.env.TWITTER_CONSUMER_SECRET = "secret";
+  ({ default: app } = await import("../server.js"));
+  ({ default: db } = await import("../lib/db.js"));
+});
+
+afterAll(async () => {
+  if (db) {
+    await db.close();
+  }
+});
+
+describe("Subscription claim", () => {
+  it("401 without session wallet", async () => {
+    const res = await request(app).post("/api/v1/subscription/claim");
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/deriveLevel.smoke.js
+++ b/tests/deriveLevel.smoke.js
@@ -1,6 +1,18 @@
 import assert from 'assert/strict';
 import { deriveLevel } from '../config/progression.js';
 
-assert.equal(deriveLevel(0).levelName, 'Shellborn');
-assert.equal(deriveLevel(250000).progress, 1);
+const shellborn = deriveLevel(0);
+assert.equal(shellborn.levelTier, 'shellborn');
+assert.equal(shellborn.progress, 0);
+assert.equal(shellborn.nextNeed, 10000);
+
+const waveSeeker = deriveLevel(15000);
+assert.equal(waveSeeker.levelTier, 'wave-seeker');
+assert.equal(waveSeeker.xpIntoLevel, 5000);
+assert.equal(Math.round(waveSeeker.progress * 100), 25);
+
+const ascendant = deriveLevel(300000);
+assert.equal(ascendant.levelName, 'Cowrie Ascendant');
+assert.equal(ascendant.progress, 1);
+assert.ok(ascendant.nextNeed >= 1);
 console.log('ok');

--- a/tests/deriveLevel.test.js
+++ b/tests/deriveLevel.test.js
@@ -1,15 +1,37 @@
-import { deriveLevel } from '../config/progression.js';
+import { deriveLevel, LEVELS } from '../config/progression.js';
 
 describe('deriveLevel', () => {
   test('handles low or negative xp as Shellborn', () => {
     const lvl = deriveLevel(-5);
     expect(lvl.levelName).toBe('Shellborn');
+    expect(lvl.levelTier).toBe('shellborn');
     expect(lvl.progress).toBe(0);
+    expect(lvl.xpIntoLevel).toBe(0);
+    expect(lvl.nextNeed).toBe(10000);
   });
 
-  test('caps at max xp', () => {
+  test('transitions tiers at defined thresholds', () => {
+    LEVELS.forEach((tier, index) => {
+      if (index === 0) return;
+      const prev = deriveLevel(tier.min - 1);
+      const cur = deriveLevel(tier.min);
+      expect(cur.levelTier).toBe(tier.key);
+      expect(cur.levelName).toBe(tier.name);
+      expect(cur.xpIntoLevel).toBe(0);
+      if (index === LEVELS.length - 1) {
+        expect(cur.progress).toBe(1);
+      } else {
+        expect(cur.progress).toBe(0);
+      }
+      expect(prev.levelTier === tier.key).toBe(false);
+    });
+  });
+
+  test('caps progress at the top tier', () => {
     const lvl = deriveLevel(300000);
     expect(lvl.levelName).toBe('Cowrie Ascendant');
     expect(lvl.progress).toBe(1);
+    expect(lvl.nextNeed).toBeGreaterThan(0);
+    expect(lvl.totalXP).toBe(300000);
   });
 });

--- a/tests/finalPolishRoutes.test.js
+++ b/tests/finalPolishRoutes.test.js
@@ -1,0 +1,110 @@
+import request from "supertest";
+
+let app;
+let db;
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = ":memory:";
+  process.env.NODE_ENV = "test";
+  process.env.TWITTER_CONSUMER_KEY = "test";
+  process.env.TWITTER_CONSUMER_SECRET = "secret";
+  process.env.FRONTEND_URL = "http://localhost:3000";
+  ({ default: app } = await import("../server.js"));
+  ({ default: db } = await import("../lib/db.js"));
+});
+
+afterAll(async () => {
+  if (db) {
+    await db.close();
+  }
+});
+
+describe("session disconnect", () => {
+  test("disconnect clears wallet from session", async () => {
+    const agent = request.agent(app);
+    await agent.post("/api/session/bind-wallet").send({ wallet: "wallet-disconnect" }).expect(200);
+
+    const before = await agent.get("/api/users/me");
+    expect(before.body.wallet).toBe("wallet-disconnect");
+
+    const disconnectRes = await agent.post("/api/session/disconnect");
+    expect(disconnectRes.body).toEqual({ ok: true });
+
+    const after = await agent.get("/api/users/me");
+    expect(after.body.wallet).toBeNull();
+  });
+});
+
+describe("subscription claim", () => {
+  test("awards xp once and is idempotent", async () => {
+    const agent = request.agent(app);
+    const wallet = "wallet-sub";
+    await agent.post("/api/session/bind-wallet").send({ wallet }).expect(200);
+
+    const first = await agent.post("/api/v1/subscription/claim");
+    expect(first.body).toMatchObject({ ok: true, xpDelta: 200 });
+
+    const second = await agent.post("/api/v1/subscription/claim");
+    expect(second.body).toMatchObject({ ok: true, xpDelta: 0 });
+
+    const row = await db.get("SELECT xp FROM users WHERE wallet = ?", wallet);
+    expect(row?.xp).toBe(200);
+  });
+});
+
+describe("referral claim", () => {
+  test("grants bonus to referrer and clears cookie", async () => {
+    await db.run(
+      `INSERT OR IGNORE INTO users (wallet, referral_code, xp, updatedAt)
+         VALUES ('referrer-wallet', 'REFCODE', 0, CURRENT_TIMESTAMP)`
+    );
+
+    const agent = request.agent(app);
+    await agent.get("/ref/REFCODE").expect(302);
+    await agent
+      .post("/api/session/bind-wallet")
+      .send({ wallet: "referred-wallet" })
+      .expect(200);
+
+    const first = await agent.post("/api/v1/referral/claim");
+    expect(first.body).toMatchObject({ ok: true, xpDelta: 50 });
+
+    const second = await agent.post("/api/v1/referral/claim");
+    expect(second.body).toMatchObject({ ok: true, xpDelta: 0 });
+
+    const referrer = await db.get(
+      "SELECT xp FROM users WHERE wallet = ?",
+      "referrer-wallet"
+    );
+    expect(referrer?.xp).toBe(50);
+  });
+});
+
+describe("social unlink", () => {
+  test("clears provider data and socials json", async () => {
+    const wallet = "social-wallet";
+    const socialsJson = JSON.stringify({ twitter: { connected: true, handle: "cowrie" } });
+    await db.run(
+      `INSERT OR REPLACE INTO users (wallet, socials, twitterHandle, twitter_username, twitter_id, updatedAt)
+         VALUES (?, ?, 'cowrie', 'cowrie', '123', CURRENT_TIMESTAMP)`,
+      wallet,
+      socialsJson
+    );
+
+    const agent = request.agent(app);
+    await agent.post("/api/session/bind-wallet").send({ wallet }).expect(200);
+
+    const res = await agent.post("/api/social/twitter/unlink");
+    expect(res.body).toEqual({ ok: true });
+
+    const row = await db.get(
+      "SELECT socials, twitterHandle, twitter_username, twitter_id FROM users WHERE wallet = ?",
+      wallet
+    );
+    expect(row.twitterHandle).toBeNull();
+    expect(row.twitter_username).toBeNull();
+    expect(row.twitter_id).toBeNull();
+    const updatedSocials = JSON.parse(row.socials);
+    expect(updatedSocials.twitter).toEqual({ connected: false });
+  });
+});

--- a/tests/leaderboardNormalization.test.js
+++ b/tests/leaderboardNormalization.test.js
@@ -25,6 +25,8 @@ describe('leaderboard normalization', () => {
     for (const e of res.body.entries) {
       expect(e.progress).toBeGreaterThanOrEqual(0);
       expect(e.progress).toBeLessThanOrEqual(1);
+      expect(e.totalXP).toBeGreaterThanOrEqual(0);
+      expect(e).toHaveProperty('levelTier');
     }
     const first = res.body.entries.find(e => e.wallet === 'w1');
     expect(first.twitterHandle).toBe('tw1');

--- a/tests/meHistoryShape.test.js
+++ b/tests/meHistoryShape.test.js
@@ -23,6 +23,10 @@ test('/api/users/me returns normalized progress and history shape', async () => 
   const res = await agent.get('/api/users/me');
   expect(res.status).toBe(200);
   const user = res.body;
+  expect(user.totalXP).toBeGreaterThanOrEqual(0);
+  expect(user).toHaveProperty('xp');
+  expect(user).toHaveProperty('nextXP');
+  expect(user).toHaveProperty('levelTier');
   expect(user.levelProgress).toBeGreaterThanOrEqual(0);
   expect(user.levelProgress).toBeLessThanOrEqual(1);
   expect(Array.isArray(user.questHistory)).toBe(true);

--- a/tests/migrateUsers.test.js
+++ b/tests/migrateUsers.test.js
@@ -9,7 +9,7 @@ describe('ensureUsersSchema migration', () => {
     await ensureUsersSchema(db);
     const cols = await db.all("PRAGMA table_info(users)");
     const names = cols.map(c => c.name);
-    const expected = ['id','wallet','xp','level','levelName','levelProgress','referral_code','referred_by','telegram_username','twitter_username','twitter_id','discord_username','discord_id','createdAt','updatedAt'];
+    const expected = ['id','wallet','xp','level','levelName','levelSymbol','levelProgress','nextXP','referral_code','referred_by','telegram_username','twitter_username','twitter_id','discord_username','discord_id','socials','createdAt','updatedAt'];
     expected.forEach(c => expect(names).toContain(c));
     const idx = await db.all("PRAGMA index_list('users')");
     const refIdx = [];

--- a/utils/cookies.js
+++ b/utils/cookies.js
@@ -1,0 +1,16 @@
+const isLocalhost = (host) =>
+  /^localhost(:\d+)?$/.test(host || "") || /^127\.0\.0\.1(:\d+)?$/.test(host || "");
+
+export function crossSiteCookieOptions(override = {}) {
+  const host = process.env.HOST || "";
+  const local = isLocalhost(host) || process.env.NODE_ENV === "development";
+  return {
+    httpOnly: true,
+    sameSite: local ? "Lax" : "none",
+    secure: local ? false : true,
+    path: "/",
+    ...override,
+  };
+}
+
+export default { crossSiteCookieOptions };

--- a/utils/session.js
+++ b/utils/session.js
@@ -1,5 +1,10 @@
 export function getSessionWallet(req) {
   const w = req?.session?.wallet;
-  return w ? String(w) : null;
+  if (typeof w !== "string") {
+    return null;
+  }
+  const trimmed = w.trim();
+  return trimmed ? trimmed : null;
 }
 
+export default { getSessionWallet };


### PR DESCRIPTION
## Summary
- Reinstate the 10k→250k level ladder as the single source of truth and update XP grants/migrations to persist the new fields
- Normalize user/profile/leaderboard responses to expose total XP, XP-in-level, next XP, and level tier/symbol data consistently
- Mirror the progression table on the frontend and refresh the profile screen to render the unified stats

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c92065f178832b8b0dc5662e3292a5