### PR TITLE
Fix token-sale API shape and frontend support payment/admin surfaces

### DIFF
--- a/routes/frontendSupportRoutes.js
+++ b/routes/frontendSupportRoutes.js
@@ -16,8 +16,10 @@ function bool(value) {
 
 function getAdminToken(req) {
   const hdr = String(req.get("authorization") || "");
-  if (!hdr.toLowerCase().startsWith("bearer ")) return "";
-  return hdr.slice(7).trim();
+  if (hdr.toLowerCase().startsWith("bearer ")) return hdr.slice(7).trim();
+  const alt = String(req.get("x-admin-token") || "").trim();
+  if (alt) return alt;
+  return "";
 }
 
 function requireAdmin(req, res, next) {
@@ -217,7 +219,7 @@ router.get("/api/payments/state", async (req, res) => {
       return res.json({ ok: true, wallet: null, subscription: null, tokenSale: null, arena: null });
     }
 
-    const [user, latestSub, tokenSaleRows, pendingArenaPayment] = await Promise.all([
+    const [user, latestSub, tokenSaleRows, tokenSaleSummary, pendingArenaPayment] = await Promise.all([
       db
         .get(
           `SELECT paid, tier, subscriptionTier, lastPaymentAt, subscriptionPaidAt, subscriptionClaimedAt
@@ -244,6 +246,15 @@ router.get("/api/payments/state", async (req, res) => {
         .catch(() => []),
       db
         .get(
+          `SELECT COUNT(*) AS total,
+                  COALESCE(SUM(CASE WHEN LOWER(COALESCE(status,'')) IN ('paid','success','succeeded','recorded') THEN 1 ELSE 0 END), 0) AS completed,
+                  COALESCE(SUM(ton_amount), 0) AS ton_total
+             FROM token_sale_contributions WHERE wallet = ?`,
+          wallet
+        )
+        .catch(() => null),
+      db
+        .get(
           `SELECT id, arena_id, status, amount, currency, checkout_url
              FROM payments
             WHERE user_wallet = ? AND status IN ('pending', 'requires_action')
@@ -268,7 +279,9 @@ router.get("/api/payments/state", async (req, res) => {
         claimedAt: user?.subscriptionClaimedAt || null,
       },
       tokenSale: {
-        totalContributions: tokenSaleRows.length,
+        totalContributions: Number(tokenSaleSummary?.total ?? tokenSaleRows.length ?? 0),
+        completedContributions: Number(tokenSaleSummary?.completed ?? 0),
+        totalTonAmount: Number(tokenSaleSummary?.ton_total ?? 0),
         latest: tokenSaleRows[0] || null,
       },
       arena: {

--- a/routes/tokenSaleRoutes.js
+++ b/routes/tokenSaleRoutes.js
@@ -10,16 +10,17 @@ const MAX_TON = Number(process.env.TOKEN_SALE_MAX_TON ?? 10_000);
 
 // --- Schema bootstrap
 await db.exec(`
-  CREATE TABLE IF NOT EXISTS contributions (
+  CREATE TABLE IF NOT EXISTS token_sale_contributions (
     id BIGSERIAL PRIMARY KEY,
     wallet TEXT,                 -- optional: user's wallet (string)
-    amountTON DOUBLE PRECISION NOT NULL, -- TON contributed
-    referral TEXT,               -- optional referral code or wallet
-    memo TEXT,                   -- optional note from user
-    createdAt TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+    ton_amount DOUBLE PRECISION NOT NULL, -- TON contributed
+    referral_code TEXT,                   -- optional referral code or wallet
+    memo TEXT,                            -- optional note from user
+    status TEXT DEFAULT 'recorded',
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
   );
-  CREATE INDEX IF NOT EXISTS idx_contrib_createdAt ON contributions(createdAt);
-  CREATE INDEX IF NOT EXISTS idx_contrib_referral ON contributions(referral);
+  CREATE INDEX IF NOT EXISTS idx_contrib_createdAt ON token_sale_contributions(created_at);
+  CREATE INDEX IF NOT EXISTS idx_contrib_referral ON token_sale_contributions(referral_code);
 `);
 
 // --- Helpers
@@ -49,9 +50,9 @@ router.post('/token-sale/contribute', async (req, res) => {
     wallet = wallet?.toString().trim() || null;
 
     const result = await db.run(
-      `INSERT INTO contributions (wallet, amountTON, referral, memo)
-       VALUES (?, ?, ?, ?)`,
-      wallet, amountTON, referral, memo
+      `INSERT INTO token_sale_contributions (wallet, ton_amount, referral_code, memo, status)
+       VALUES (?, ?, ?, ?, ?)`,
+      wallet, amountTON, referral, memo, 'recorded'
     );
 
     return res.json({
@@ -72,15 +73,20 @@ router.get('/token-sale/stats', async (_req, res) => {
     const row = await db.get(`
       SELECT
         COUNT(*)            AS contributions,
-        ROUND(COALESCE(SUM(amountTON), 0), 4) AS totalTON,
-        ROUND(COALESCE(AVG(amountTON), 0), 4) AS avgTON
-      FROM contributions
+        ROUND(COALESCE(SUM(ton_amount), 0), 4) AS "totalTON",
+        ROUND(COALESCE(AVG(ton_amount), 0), 4) AS "avgTON"
+      FROM token_sale_contributions
     `);
 
     const recent = await db.all(
-      `SELECT id, wallet, amountTON, referral, memo, createdAt
-       FROM contributions
-       ORDER BY createdAt DESC
+      `SELECT id,
+              wallet,
+              ton_amount AS "amountTON",
+              referral_code AS referral,
+              memo,
+              created_at AS "createdAt"
+       FROM token_sale_contributions
+       ORDER BY created_at DESC
        LIMIT 10`
     );
 
@@ -96,9 +102,14 @@ router.get('/token-sale/contributions', async (req, res) => {
   try {
     const limit = Math.min(Number(req.query.limit ?? 50), 200);
     const rows = await db.all(
-      `SELECT id, wallet, amountTON, referral, memo, createdAt
-       FROM contributions
-       ORDER BY createdAt DESC
+      `SELECT id,
+              wallet,
+              ton_amount AS "amountTON",
+              referral_code AS referral,
+              memo,
+              created_at AS "createdAt"
+       FROM token_sale_contributions
+       ORDER BY created_at DESC
        LIMIT ?`,
       limit
     );


### PR DESCRIPTION
### Motivation
- Frontend audit showed token-sale pages and the payments state UI received inconsistent/mismatched payloads and missing aggregates, causing empty or broken frontend widgets. 
- Admin-facing frontend pages expected an easy admin token header format that the backend did not accept, blocking admin workflows. 
- The token-sale contribution endpoints were duplicating/aliasing a different schema and produced field names the frontend did not expect.

### Description
- Unified token-sale contribution handling to use the canonical `token_sale_contributions` table and wrote contributions with `ton_amount`, `referral_code`, `status`, and `created_at` to keep parity with webhook/ingest flows (`routes/tokenSaleRoutes.js`).
- Kept frontend-compatible response shapes by aliasing columns to camelCase (`amountTON`, `createdAt`) and exposing `totalTON` / `avgTON` in stats responses so existing UI code works without change (`routes/tokenSaleRoutes.js`).
- Extended the payments state surface at `/api/payments/state` to return token-sale aggregates (`totalContributions`, `completedContributions`, `totalTonAmount`) and the latest contribution row to make the UI honest about payment state (`routes/frontendSupportRoutes.js`).
- Relaxed admin auth header handling for frontend admin pages to accept `x-admin-token` in addition to `Authorization: Bearer <token>` so UI/automation can authenticate without changing secret handling (`routes/frontendSupportRoutes.js`).
- Files changed: `routes/tokenSaleRoutes.js`, `routes/frontendSupportRoutes.js`.

### Testing
- Static checks: `node --check routes/tokenSaleRoutes.js` and `node --check routes/frontendSupportRoutes.js` completed successfully. 
- Lint: `npm run lint -- routes/tokenSaleRoutes.js routes/frontendSupportRoutes.js` completed successfully. 
- Route verification: verified route declarations and usage via ripgrep (`rg`) to confirm `/token-sale/*` and `/api/payments/state` mounts. 
- Integration tests: attempted `npm test` (Jest) but full suite could not run here because a live Postgres `DATABASE_URL` is required in this environment, so end-to-end/integration tests were not executed (failing for missing DB config).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8410bea80832b82b611a1bfeaac51)